### PR TITLE
Add Govwifi specifics to dev docs template

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,16 +3,16 @@ host: dev-docs.wifi.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true
-service_name: My First Service
-service_link: https://www.larry-the-cat.service.gov.uk
+service_name: Govwifi
+service_link: https://www.wifi.service.gov.uk/
 phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  About: https://www.larry-the-cat.service.gov.uk
-  Get Started: https://www.larry-the-cat.service.gov.uk/get-started
+  About: https://www.wifi.service.gov.uk/about-govwifi/
+  Get Started: /
   Documentation: /
-  Support: https://www.larry-the-cat.service.gov.uk/support
+  Support: https://www.wifi.service.gov.uk/support/
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: false
@@ -35,4 +35,4 @@ max_toc_heading_level: 6
 prevent_indexing: false
 
 show_contribution_banner: true
-github_repo: alphagov/YOUR_REPO
+github_repo: alphagov/govwifi-dev-docs

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,7 @@ header_links:
   Support: https://www.wifi.service.gov.uk/support/
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
-enable_search: false
+enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -1,21 +1,28 @@
-# Hello, World!
+# Govwifi developer documentation
 
-## Edit Me!
+This is the technical documentation for the [Govwifi](https://www.wifi.service.gov.uk/) team in the [Government Digital Service (GDS)](https://gds.blog.gov.uk/). For other projects built by GDS, see the [Service Toolkit](https://www.gov.uk/service-toolkit).
 
-Open `source/documentation/index.md` in your favourite text editor and start editing!
+## Applications overview
 
-You can write content in [Markdown](https://daringfireball.net/projects/markdown/) using **all** of the _usual_ syntax that you're used to!
+Our public-facing websites are:
 
-This means you can use things like tables:
+- A [product page](https://github.com/alphagov/govwifi-product-page) explaining the benefits of GovWifi
+- An [admin platform](https://github.com/alphagov/govwifi-admin) for organiations to self-serve changes to their GovWifi installation
+- [Technical documentation](https://github.com/alphagov/govwifi-tech-docs), explaining GovWifi in more detail
+- A [redirection service](https://github.com/alphagov/govwifi-redirect) to handle "www" requests to these sites
 
-Food | Kind | Tasty?
---- | --- | ---
-Bananas | Fruit | Yes
-Aubergines | Vegetable | No
-Apricots | Fruit | Yes
+Our services include:
+- [Frontend servers](https://github.com/alphagov/govwifi-frontend), instances of freeRADIUS that act as authentication servers
 
-To change the title of the page or include additional files you'll need to edit `source/index.html.md.erb`.
+- An [authentication API](https://github.com/alphagov/govwifi-authentication-api), which the frontend calls to help authenticate GovWifi requests
+- A [logging API](https://github.com/alphagov/govwifi-logging-api), which the frontend calls to record each GovWifi request
+- A [user signup API](https://github.com/alphagov/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
 
-If you want slightly more control, you can always use <strong>HTML</strong>.
+We manage our infrastructure via:
 
-For more detail and troubleshooting, take a look at the `README.md` file in the root of this project.
+- Terraform, see [govwifi-terraform](https://github.com/alphagov/govwifi-terraform)
+- The [safe restarter](https://github.com/alphagov/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the frontends
+
+Other repositories:
+
+- [Acceptance tests](https://github.com/alphagov/govwifi-acceptance-tests), which pulls together GovWifi end-to-end, from the various repositories, and runs tests against it.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GOV.UK Documentation Example
+title: Govwifi Developer Documentation
 ---
 
 <%= partial 'documentation/index' %>


### PR DESCRIPTION
Updates a few things:

- Service title
- Default page title
- Enables documentation search
- Updates index page with some initial details - more to add here in future PRs

![Screenshot from 2019-05-31 10-39-00](https://user-images.githubusercontent.com/93511/58696882-671d1800-8390-11e9-9e83-12bed55389d4.png)
