### PR TITLE
Fix AWS config example formatting

### DIFF
--- a/source/documentation/setting_up_terraform.md
+++ b/source/documentation/setting_up_terraform.md
@@ -10,6 +10,7 @@ There are several prerequisites to running [govwifi-terraform](https://github.co
 - You have an AWS IAM user with the ability to assume a suitable role (RE:D team can set this up).
 - Your AWS configuration contains an appropriate profile wth the suitable role.
   eg.
+
   ```
   [profile govwifi]
   region = eu-west-1


### PR DESCRIPTION
The AWS config example should be in a code block but it's currently rendered inline.