### PR TITLE
Make concourse pipeline consistent with tech docs

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -25,11 +25,9 @@ resources:
     type: git
     source:
       uri: "https://github.com/alphagov/govwifi-dev-docs.git"
-      branch: master
 
   - name: govwifi-dev-docs-pr
     type: pull-request
-    check_every: 1m
     source:
       repository: alphagov/govwifi-dev-docs
       access_token: ((github-access-token))
@@ -44,7 +42,6 @@ resources:
       space: "production"
       username: ((govpaas-username))
       password: ((govpaas-password))
-      skip_cert_check: false
 
 jobs:
   - name: self-update
@@ -131,6 +128,7 @@ jobs:
             path: sh
             dir: repo
             args:
+            - -eu
             - -c
             - |
               apt-get update


### PR DESCRIPTION
We recently refactored the tech docs pipeline to be consistent with dev docs. We made a few minor changes. This commit brings this pipeline in sync with those changes

Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>

```
diff --git a/ci/pipelines/build-and-deploy.yml b/../govwifi-tech-docs/ci/pipelines/build-and-deploy.yml
index 7811db9..19a761b 100644
--- a/ci/pipelines/build-and-deploy.yml
+++ b/../govwifi-tech-docs/ci/pipelines/build-and-deploy.yml
@@ -21,15 +21,15 @@ resources:
     source:
       uri: https://github.com/alphagov/tech-ops.git

-  - name: govwifi-dev-docs
+  - name: govwifi-tech-docs
     type: git
     source:
-      uri: "https://github.com/alphagov/govwifi-dev-docs.git"
+      uri: "https://github.com/alphagov/govwifi-tech-docs.git"

-  - name: govwifi-dev-docs-pr
+  - name: govwifi-tech-docs-pr
     type: pull-request
     source:
-      repository: alphagov/govwifi-dev-docs
+      repository: alphagov/govwifi-tech-docs
       access_token: ((github-access-token))
       disable_forks: true

@@ -50,30 +50,30 @@ jobs:
     - get: tech-ops
       params:
         submodules: none
-    - get: govwifi-dev-docs
+    - get: govwifi-tech-docs
       trigger: true
     - task: set-pipelines
       file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-dev-docs}
+      input_mapping: {repository: govwifi-tech-docs}
       params:
         CONCOURSE_TEAM: govwifi
         CONCOURSE_PASSWORD: ((readonly_local_user_password))
         PIPELINE_PATH: ci/pipelines/build-and-deploy.yml
-        PIPELINE_NAME: dev-docs-deploy
+        PIPELINE_NAME: tech-docs-deploy

   - name: build
     interruptible: true
     disable_manual_trigger: true
     serial: true
     plan:
-      - get: govwifi-dev-docs-pr
+      - get: govwifi-tech-docs-pr
         trigger: true
         version: every
-      - put: govwifi-dev-docs-pr
+      - put: govwifi-tech-docs-pr
         params:
           status: pending
-          path: govwifi-dev-docs-pr
-      - task: bundle-govwifi-dev-docs-pr
+          path: govwifi-tech-docs-pr
+      - task: bundle-govwifi-tech-docs-pr
         timeout: 15m
         config:
           platform: linux
@@ -83,7 +83,7 @@ jobs:
               repository: gdsre/aws-ruby
               tag: 2.6.1-3.0.1
           inputs:
-            - name: govwifi-dev-docs-pr
+            - name: govwifi-tech-docs-pr
               path: repo
           run:
             path: sh
@@ -96,21 +96,21 @@ jobs:
               bundle install --without development
               bundle exec middleman build
     on_success:
-      put: govwifi-dev-docs-pr
+      put: govwifi-tech-docs-pr
       params:
-        path: govwifi-dev-docs-pr
+        path: govwifi-tech-docs-pr
         status: success
     on_failure:
-      put: govwifi-dev-docs-pr
+      put: govwifi-tech-docs-pr
       params:
-        path: govwifi-dev-docs-pr
+        path: govwifi-tech-docs-pr
         status: failure
   - name: deploy
     serial: true
     plan:
-      - get: govwifi-dev-docs
+      - get: govwifi-tech-docs
         trigger: true
-      - task: bundle-govwifi-dev-docs
+      - task: bundle-govwifi-tech-docs
         timeout: 15m
         config:
           platform: linux
@@ -120,7 +120,7 @@ jobs:
               repository: gdsre/aws-ruby
               tag: 2.6.1-3.0.1
           inputs:
-            - name: govwifi-dev-docs
+            - name: govwifi-tech-docs
               path: repo
           outputs:
             - name: bundled
```