### PR TITLE
Add info about access tokens being for team monitor

### DIFF
--- a/source/documentation/team-dashboard.md
+++ b/source/documentation/team-dashboard.md
@@ -17,16 +17,17 @@ of GovWifi in realtime.
 GovWifi has its own organisation, and we have admin-level access so we can now make our own changes 
 without having to always involve RE. 
 
-We currently have two dashboards in Grafana:
+We currently have two dashboards in Grafana, which are both shown on the TV monitor:
 
 1. The first is for monitoring performance of GovWifi Product Pages and Tech Docs, and is available
 [here](https://grafana-paas.cloudapps.digital/d/KMxSG3DWk/govwifi).
 
 2. The second is for monitoring GovWifi's SLIs for authentication journeys, as well as success rates
 for SMS and email responses, and is available
-[here](https://grafana-paas.cloudapps.digital/d/THPLfGxWk/govwifi-cloudwatch.
-
-Both of these are currently shown on the TV monitor.
+[here](https://grafana-paas.cloudapps.digital/d/THPLfGxWk/govwifi-cloudwatch).
+    
+    Grafana currently gets these metrics from AWS CloudWatch. In order to grant Grafana access to
+    these, we are using an access key generated for the `monitor` IAM user in our AWS account.
 
 ### Concourse
 
@@ -45,6 +46,9 @@ Fourth Wall is a GDS application for monitoring pull requests and their build st
 
 We list all of our repositories on Fourth Wall on the TV monitor, as it helps in identifying 
 important and urgent pull requests that should be prioritised.
+
+In order for Fourth Wall to make calls to Github's APIs, we're using a personal access token
+generated for our `github-jenkins` Github user.
 
 ### Google Analytics
 


### PR DESCRIPTION
Since we're using a couple of access tokens, I feel the docs need to clarify this.