### PR TITLE
BAU: bump all packages to latest, including tech-docs gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.20.1)
+    commonmarker (0.20.2)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -73,7 +73,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    memoist (0.16.1)
+    memoist (0.16.2)
     method_source (0.9.2)
     middleman (4.3.5)
       coffee-script (~> 2.2)
@@ -127,7 +127,7 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 2.0)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multi_json (1.14.1)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -143,12 +143,12 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.1)
-    rack (2.0.8)
+    public_suffix (4.0.3)
+    rack (2.1.1)
     rack-livereload (0.3.17)
       rack
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.3.4)
     rouge (2.2.1)
@@ -162,10 +162,10 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.2)
-    thor (0.20.3)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
@@ -177,6 +177,3 @@ DEPENDENCIES
   govuk_tech_docs
   tzinfo-data
   wdm (~> 0.1.0)
-
-BUNDLED WITH
-   1.17.2


### PR DESCRIPTION
We're missing a dependabot config in this repo. In the meantime, bump everything. Low risk as it's not user facing.