### PR TITLE
Update the Grafana links since we now have our own instance of Grafana

### DIFF
--- a/source/documentation/team-dashboard.md
+++ b/source/documentation/team-dashboard.md
@@ -20,11 +20,11 @@ without having to always involve RE.
 We currently have two dashboards in Grafana, which are both shown on the TV monitor:
 
 1. The first is for monitoring performance of GovWifi Product Pages and Tech Docs, and is available
-[here](https://grafana-paas.cloudapps.digital/d/KMxSG3DWk/govwifi).
+[here](https://grafana-paas.cloudapps.digital/d/KMxSG3DWk/govwifi-product-page-and-tech-docs?orgId=4).
 
 2. The second is for monitoring GovWifi's SLIs for authentication journeys, as well as success rates
 for SMS and email responses, and is available
-[here](https://grafana-paas.cloudapps.digital/d/THPLfGxWk/govwifi-cloudwatch).
+[here](https://grafana-paas.cloudapps.digital/d/THPLfGxWk/govwifi-slis?orgId=4).
     
     Grafana currently gets these metrics from AWS CloudWatch. In order to grant Grafana access to
     these, we are using an access key generated for the `monitor` IAM user in our AWS account.


### PR DESCRIPTION
Back story: We used to have our dashboards on a shared Grafana instance.
Now (since last quarter), we have our own instance.