### PR TITLE
Update accessing GovWifi AWS Web Console

### DIFF
--- a/source/documentation/accessing-the-infrastructure.md
+++ b/source/documentation/accessing-the-infrastructure.md
@@ -2,7 +2,7 @@
 
 ## AWS Console
 
-Access is via [gds-users][https://gds-users.signin.aws.amazon.com/console] and then assuming your role from the GovWifi account.
+Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and then assuming your role from the GovWifi account.
 
 Staging and Production are hosted within the same AWS account.
 

--- a/source/documentation/accessing-the-infrastructure.md
+++ b/source/documentation/accessing-the-infrastructure.md
@@ -2,12 +2,11 @@
 
 ## AWS Console
 
-The GovWifi Account ID is `788375279931`.
+Access is via [gds-users][https://gds-users.signin.aws.amazon.com/console] and then assuming your role from the GovWifi account.
 
-This can be used for logging into the console, or for assumed roles.
+Staging and Production are hosted within the same AWS account.
 
-Use `https://788375279931.signin.aws.amazon.com/console` or `https://govwifi.signin.aws.amazon.com/console` for
-accessing the AWS console.
+The GovWifi Account ID is `788375279931` and your role is in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
 
 ## VPN
 


### PR DESCRIPTION
We now access it only via assuming a role after logging in via
gds-users, this updates the documentation to capture this change.