### PR TITLE
Enable ZDD to PaaS

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -139,6 +139,7 @@ jobs:
               cp manifest.yml ../build
       - put: deploy-to-paas
         params:
+          current_app_name: govwifi-dev-docs
           manifest: build/manifest.yml
           show_app_log: true
           path: build


### PR DESCRIPTION
Seems to have worked for product site, so replicating to dev docs, because downtime is bad!

### Context

The `cf` resource [docs](https://github.com/cloudfoundry-community/cf-resource) say providing `current_app_name` param will perform ZDD.