### PR TITLE
Add live service routes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
   path: ./build
   buildpacks:
    - staticfile_buildpack
+  routes:
+    - route: govwifi-dev-docs.cloudapps.digital


### PR DESCRIPTION
When the deploy happens, it uses the zero downtime plugin, which needs all routes to be in the manifest, because it creates a new app.

See https://github.com/alphagov/govwifi-product-page/pull/252 for reference.