### PR TITLE
further docs updates

### DIFF
--- a/source/documentation/accessing-the-infrastructure.md
+++ b/source/documentation/accessing-the-infrastructure.md
@@ -76,31 +76,18 @@ Remember that there are 2 regions, so there may be more than 2 bastions.
 
 #### SSH Config
 
-It is recommended to set up an ssh config for ease of use. All further instructions will
-assume you use similar naming.
+It is recommended to set up an ssh config for ease of use. Instructions how to
+set up your SSH config is in the Password Store of Govwifi where you can run:
 
-**Note**: The IP addresses have been redacted. Please substitute in the correct IP addresses.
-
-```
-AddKeysToAgent = yes
-
-Host govwifi-bastion-london-staging <redacted IP address>
-    Hostname <redacted IP address>
-    User ubuntu
-    IdentityFile ~/.ssh/govwifi/bastion-staging
-
-Host govwifi-bastion-london-production <redacted IP address>
-    Hostname <redacted IP address>
-    User ubuntu
-    IdentityFile ~/.ssh/govwifi/bastion-production
-
-Host govwifi-bastion-ireland-production <redacted IP address>
-    Hostname <redacted IP address>
-    User ubuntu
-    IdentityFile ~/.ssh/govwifi/bastion-production
+```sh
+PASSWORD_STORE_DIR=<password_store_dir> pass show ssh/instructions.txt
 ```
 
-You should now be able to connect to each of the hosts using ssh.
+where `<password_store_dir>` is the path of the `passwords` directory of the
+[govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
+local machine.
+
+You should now be able to connect to each of the hosts using ssh. For e.g.
 
 ```sh
 ssh govwifi-bastion-london-staging

--- a/source/documentation/monitoring.md
+++ b/source/documentation/monitoring.md
@@ -2,7 +2,7 @@
 
 We now have dashboards!
 
-We currently display dashboards on our TV monitors (two of them), running on ChromeOS. This section 
+We currently display dashboards on our TV monitors (two of them), running on ChromeOS. This section
 outlines what's currently displayed on them.
 
 ## Technical
@@ -20,7 +20,7 @@ without having to always involve RE.
 We currently have two dashboards in Grafana, which are both shown on the TV monitor:
 
 1. The first is for monitoring performance of GovWifi Product Pages and Tech Docs, and is available
-[here](https://grafana-paas.cloudapps.digital/d/KMxSG3DWk/govwifi-product-page-and-tech-docs?orgId=4).
+[here](https://grafana-paas.cloudapps.digital/d/KMxSG3DWk/govwifi).
 
 2. The second is for monitoring GovWifi's SLIs for authentication journeys, as well as success rates
 for SMS and email responses, and is available

--- a/source/documentation/secrets.md
+++ b/source/documentation/secrets.md
@@ -1,8 +1,10 @@
 # GovWifi Secrets
 
-All secrets are stored in https://github.com/alphagov/govwifi-build, and are encrypted using GPG.
+All secrets are stored in [govwifi-build][govwifi-build], and are encrypted using GPG.
 
-All shell commands assume you are running from within the [`govwifi-terraform`][govwifi-terraform] repository.
+All shell commands assume you are running from within the [`govwifi-terraform`][govwifi-terraform]
+repository since the [govwifi-build][govwifi-build] repository is cloned in the
+`.private` directory of [`govwifi-terraform`][govwifi-terraform].
 
 ## Tools
 
@@ -64,14 +66,25 @@ Throughout the documentation, there will be references to specific secrets store
 To read individual secrets, run the command:
 
 ```sh
-PASSWORD_STORE_DIR=.private/passwords pass show '<secret name>'
+PASSWORD_STORE_DIR=<password_store_dir> pass show <secret_name>
+```
 
-# example, access the Staging Bastion SSH Key
+where:
+
+1. `<password_store_dir>` is the path of the `passwords` directory of the
+[govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
+local machine.
+
+2. `<secret_name>` is the path of the secret that you want to display. You can omit
+   this to get a list of all secret paths.
+
+For example, if you want to access the Staging Bastion SSH Key:
+
+```sh
 PASSWORD_STORE_DIR=.private/passwords pass show keys/govwifi-staging-bastion-key
 ```
 
 
-
-
 [passwordstore]: https://www.passwordstore.org/
 [govwifi-terraform]: https://github.com/alphagov/govwifi-terraform
+[govwifi-build]: https://github.com/alphagov/govwifi-build


### PR DESCRIPTION
1. Update ssh instructions as it is easier to get the full config with the IPs from the password store directly
2. Update first grafana link, unfortunately 2nd link has not been updated as can't see where it should correctly be linked to.
3. Clarify that govwifi-build is a repo which is cloned inside the .private folder of govwifi-terraform