### PR TITLE
Use new govsvc/aws-ruby image

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -80,8 +80,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: govwifi-dev-docs-pr
               path: repo
@@ -118,8 +118,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: govwifi-dev-docs
               path: repo


### PR DESCRIPTION
This image is now continuously deployed, we should prefer it.  We're
moving away from the `gdsre` organisation to the `govsvc` one.