### PR TITLE
Update Tech Docs Template fixes deadline

### DIFF
--- a/source/accessibility-statement.html.md
+++ b/source/accessibility-statement.html.md
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GovWifi Team Manual
-last_reviewed_on: 2020-09-21
+last_reviewed_on: 2020-12-21
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -86,12 +86,12 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the accessibility issues in the content by the end of 2020.
+We plan to fix the accessibility issues in the content by the end of March 2021.
 
-We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 18 September 2020. It was last reviewed on 21 September 2020.
+This statement was prepared on 18 September 2020. It was last reviewed on 21 December 2020.
 
 This website was last tested in August 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample of pages from each section of the site.


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.

Paired with: @sabrinaharris 