### PR TITLE
Amend SSH instructions for clarity

### DIFF
--- a/source/documentation/accessing-the-infrastructure.md
+++ b/source/documentation/accessing-the-infrastructure.md
@@ -91,7 +91,7 @@ where `<password_store_dir>` is the path of the `passwords` directory of the
 [govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
 local machine.
 
-You should now be able to connect to each of the hosts using ssh and the hostnames mentioned in `instructions.txt`
+You should now be able to connect to each of the hosts using ssh and the hostnames mentioned in `instructions.txt`.
 
 Example: 
 

--- a/source/documentation/accessing-the-infrastructure.md
+++ b/source/documentation/accessing-the-infrastructure.md
@@ -91,10 +91,12 @@ where `<password_store_dir>` is the path of the `passwords` directory of the
 [govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
 local machine.
 
-You should now be able to connect to each of the hosts using ssh. For e.g.
+You should now be able to connect to each of the hosts using ssh and the hostnames mentioned in `instructions.txt`
+
+Example: 
 
 ```sh
-ssh govwifi-bastion-london-staging
+ssh example.hostname
 ```
 
 ## Databases


### PR DESCRIPTION
* Clarify that developers should use the hostnames mentioned in the instructions.txt file, not `govwifi-bastion-london-staging`.