### PR TITLE
Add Documentation For Renewing Jenkins Key

### DIFF
--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: How to renew the Jenkins GPG Key
+weight: 100
+last_reviewed_on: 2021-01-25
+review_in: 6 months
+---
+
+# How To Renew The Jenkins GPG Key
+
+If you see an error stating that this key has expired, please contact the SRE
+team. You may encounter this error when trying to re-encrypt the secrets in
+[govwifi-build](https://github.com/alphagov/govwifi-build) or in output of one of our Concourse pipelines - [such as this one](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/sync-frontend-certs).
+
+If you are a member of the SRE team and you are looking for further
+documentation, please see the instructions in Google Drive in the private GovWifi
+Team folder (Govwifi > Technical:developer work > Tech Docs ) entitled
+"Rotate Jenkins GPG Key".


### PR DESCRIPTION
Explicit instructions have been placed in the team Google Drive following advice from the IT Healthcheck.