### PR TITLE
Use nodejs 14.X

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -133,6 +133,7 @@ jobs:
             - -c
             - |
               apt-get update
+              curl -sL https://deb.nodesource.com/setup_14.x | bash -
               apt-get install -y nodejs
               bundle install --without development
               bundle exec middleman build


### PR DESCRIPTION
Upgrade to nodejs 14.X in the concourse pipeline.

On updating some gems we're seeing an error due to the old node being used. Changing the pipeline on the branch doesn't help - we think that this is read from `master`. So if we can get that change into `master` the branch should then build. 🤞🏻 