### PR TITLE
bumped kramdown from 2.3.0 to 2.3.1 due to vuln

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -79,7 +79,7 @@ GEM
     middleman (4.3.8)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
-      kramdown (>= 2.3.0)
+      kramdown (>= 2.3.1)
       middleman-cli (= 4.3.8)
       middleman-core (= 4.3.8)
     middleman-autoprefixer (2.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     middleman (4.3.8)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
-      kramdown (>= 2.3.1)
+      kramdown (>= 2.3.0)
       middleman-cli (= 4.3.8)
       middleman-core (= 4.3.8)
     middleman-autoprefixer (2.7.1)


### PR DESCRIPTION
bumped kramdown from 2.3.0 to 2.3.1 due to https://github.com/advisories/GHSA-52p9-v744-mwjj