### PR TITLE
Update GPG on-boarding instructions

### DIFF
--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -48,7 +48,7 @@ gpg --keyserver hkps.pool.sks-keyservers.net --send-keys '<your key ID>'
 
 The new joiner must first send their GPG key ID to a current member of the team .
 
-Once the key is received, a team member must use the `receive-keys` option to accept and provide it `ultimate` trust:
+Once the key is received, a team member must use the `receive-keys` option to accept it and provide the key with `ultimate` trust:
 
 ```sh
 key_id='<their key ID>'

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -48,7 +48,7 @@ gpg --keyserver hkps.pool.sks-keyservers.net --send-keys '<your key ID>'
 
 The new joiner must first send their GPG key ID to a current member of the team .
 
-Once the key is received, a team member must use the `receive-keys` command to accept and trust it:
+Once the key is received, a team member must use the `receive-keys` option to accept and provide it `ultimate` trust:
 
 ```sh
 key_id='<their key ID>'

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -46,7 +46,9 @@ gpg --keyserver hkps.pool.sks-keyservers.net --send-keys '<your key ID>'
 
 ## Giving Access
 
-Once you have received someone's GPG Key ID, you must receive it, and trust it:
+The new joiner must first send their GPG key ID to a current member of the team .
+
+Once the key is received, a team member must use the `receive-keys` command to accept and trust it:
 
 ```sh
 key_id='<their key ID>'
@@ -54,17 +56,31 @@ gpg --keyserver keyserver.ubuntu.com --receive-keys "$key_id"
 echo "${key_id}:6" | gpg --import-ownertrust
 ```
 
-Append the `.private/passwords/.gpg-id` file with their key:
+To on-board the new GPG key, navigate to the `.private` directory in the `govwifi-terraform` project.
+
+Checkout a new branch in `.private`:
+
+```sh
+$ git checkout -b onboarding_<NAME>_GPG_key
+```
+
+Append the new key to the `.private/passwords/.gpg-id` file:
 
 ```sh
 echo "$key_id" >> '.private/passwords/.gpg-id'
 ```
 
-then re-encrypt the passwords from within the [`govwifi-terraform`][govwifi-terraform] repo:
+Change directory to the root project (`govwifi-terraform/`), then re-encrypt the passwords from within the [`govwifi-terraform`][govwifi-terraform] repo:
 
 ```sh
 make rencrypt-passwords
 ```
+
+Note: `make` commands can only be run from the root project directory.
+
+Once the secrets have been re-encrypted, use git to commit and push the changes in the `.private` directory.
+
+Raise a PR in the `govwifi-build` repo on Github. Ask another team member to test the encryption has worked by checking out the PR branch and testing they can decrypt the files using `gpg -d`.
 
 ## Getting a secret
 


### PR DESCRIPTION
### What

Add more granular steps to on-boarding a new joiner's GPG key.

### Why

The existing documentation wasn't clear enough. I just on-boarded David Pye and noticed the documentation could be clearer.