### PR TITLE
Link to architecture diagram in Google Drive

### DIFF
--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Learn about the infrastructure
 
-This section gives an overview of the GovWifi infrastructure.
+This section gives an overview of the GovWifi infrastructure. A diagram of our infrastructure is available [here](https://drive.google.com/drive/u/0/folders/1G3JIDH6JOx6VUhlnx4pVIl2gOKFQThj3).
 
 ## VPN
 


### PR DESCRIPTION
### What

Add link to architecture diagram in the team's drive. The diagram is only accessible to those who have permission to view the team drive (I've tested this).

### Why

It should be easy for new joiners to find a link to our architecture diagram so they can learn about how GovWifi works.