### PR TITLE
New page: how to update GovWifi content

### DIFF
--- a/source/style-guide.html.md.erb
+++ b/source/style-guide.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Style guide
-weight: 10
+weight: 20
 last_reviewed_on: 2021-01-10
 review_in: 6 months
 ---
@@ -97,7 +97,7 @@ The group of people who use the GovWifi admin are admin users. They have a GovWi
 
 Internally it’s fine to refer to it as the admin site or application.
 
-### IP address 
+### IP address
 
 Or IP addresses. Do not use IP or IPs.
 

--- a/source/update-govwifi-content.html.md.erb
+++ b/source/update-govwifi-content.html.md.erb
@@ -1,0 +1,144 @@
+---
+title: How to update GovWifi content
+weight: 10
+last_reviewed_on: 2021-06-14
+review_in: 12 months
+---
+
+# How to update GovWifi content
+
+For each type of content that makes up the GovWifi service, this page explains what it is, who is responsible for it and how to update it.
+
+## Product pages
+
+### What
+
+The [product pages](https://www.wifi.service.gov.uk/) contain information for end users about how to connect to GovWifi and troubleshoot any problems they’re having.
+
+Here’s the [product pages repo](https://github.com/alphagov/govwifi-product-page). They’re written in Ruby.
+
+### Who
+
+A content designer should be responsible for updates to the product pages.
+
+### How
+
+To update the content, you can either write your updates in a Google doc and give it to a developer, or do it yourself.
+
+If you’re happy doing things yourself, follow the instructions on the repo to run the pages locally, make your changes and preview them. You’ll need a dev build laptop to do this.
+
+When you’ve raised the PR for your changes, get a review from a developer and a content person. There will be a button on the PR page that says ‘view deployment’ which lets people see your changes.
+
+Ask a developer if you need help.
+
+There’s a [Google datastudio dashboard](https://datastudio.google.com/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB) to see how these pages are performing.
+
+## Technical documentation
+
+### What
+
+The [technical documentation](https://docs.wifi.service.gov.uk/) includes an overview of what GovWifi is, and instructions on how to set up and manage GovWifi for organisations.
+
+Here’s the [tech docs repo](https://github.com/alphagov/govwifi-tech-docs). The code is based on the tech docs template owned by the technical writers. You can edit the content using Markdown.
+
+### Who
+
+A technical writer or content designer should be responsible for any updates to the tech docs.
+
+### How
+
+There are two ways to update it depending what you need to do:
+
+- to make big or structural changes, follow the instructions on the repo to run the pages locally, make your changes and preview them
+- to make smaller changes, you can just make the changes in Github and you’ll still get a good sense of what they’ll look like
+
+If the team does not have a technical writer, get a 2i from one if you can.
+
+Ask a developer if you need help. Use the [Govspeak preview app](https://govspeak-preview.herokuapp.com/) if you need help with Markdown.
+
+There’s a [Google data studio dashboard](https://datastudio.google.com/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB) to see how these pages are performing.
+
+## GovWifi admin
+
+### What
+
+GovWifi admin is where admin users can set up GovWifi for their organisation and view user logs.
+
+This is [GovWifi admin (production)](https://admin.wifi.service.gov.uk/users/sign_in). This is [GovWifi admin (staging)](https://admin.staging.wifi.service.gov.uk/users/sign_in).
+
+Here’s the [GovWifi admin repo](https://github.com/alphagov/govwifi-admin). It’s written in Ruby.
+
+### Who
+
+A content designer should be responsible for any updates to the content in GovWifi admin - usually with help from an interaction designer.
+
+### How
+
+To update the content, plan your updates in a Google doc or Figma (or however else you prefer). There’s a [Figma version of the admin site](https://www.figma.com/file/me3ikTJIEYaAam0cCucEVm/GovWifi?node-id=130%3A2) that you might find it helpful to draft your edits in.
+
+Then, depending how big your changes are, give them to a developer or make them yourself.
+
+If you can make the changes yourself, follow the instructions on the repo to run the pages locally, make your changes and preview them. You’ll need a dev build laptop to do this.
+
+When you’ve raised the PR for your changes, get a review from a developer and a designer or content person, depending on the change.
+
+## Texts and emails
+
+### What
+
+The texts and emails live in the two GovWifi Notify accounts - [GovWifi Notify (production)](https://www.notifications.service.gov.uk/services/d1844f74-3895-4a8b-8f75-3eb929763d16) and [GovWifi Notify (staging)](https://www.notifications.service.gov.uk/sign-in?next=%2Fservices%2F8a09d848-d453-4aea-bb1e-46f7d19a1814%2Ftemplates%2Fall).
+
+Edit and test your messages from the staging account first.
+
+### Who
+
+A content designer should do any updates to the texts and emails if they’re part of the GovWifi service journey. A content designer and engagement lead should be responsible for comms. Other roles may sometimes need to use Notify too - for example the user researcher may need to send out a survey.
+
+### How
+
+Once you’re added to the GovWifi Notify account, you can create text and email templates in it.
+
+When writing texts:
+
+- keep them as short as possible due to the character count and charge per text message - you can see the character count and associated charge in Notify, and here’s the pricing information
+- bear in mind you cannot do much formatting except keyboard characters
+- always test on a phone and with assistive tech on a phone - for example, inbuilt screen readers may read out content differently to desktop ones, and screen  magnification may cut off words in a confusing way (for example, users may interpret passwords as having a space in the middle)
+
+When writing emails:
+
+- make the subject line informative so users can get the key messages from it
+- we can segment the audience based to some extent - ask the developers to pull the list of admin users’ email addresses from the database and ask if they can filter it to your needs
+- you don’t need to worry about the volume or pricing, because sending emails is free
+- consider whether you need to post the content in the #govwifi cross-gov Slack channel too (usually a good idea if it’s a comms email and you’ve segmented the mailing list somehow)
+
+Once your texts or emails are sent, you can see how many people they were successfully delivered too.
+
+There are also some analytics in Notify, such as how many times each of your templates have been sent over different time periods.
+
+## User support macros
+
+### What
+
+User support macros are template responses that the team can use to respond to common support questions quickly. They’re stored in [Zendesk](https://govuk.zendesk.com/agent/dashboard).
+
+### Who
+
+A content designer should do any updates to the user support macros. The team can then adjust the content as needed depending on the question they’re replying to.
+
+### How
+
+Once you’ve been added to the GovWifi second line view on Zendesk:
+
+1. Select the ‘settings’ cog icon in the menu sidebar.
+1. Select ‘Macros’ in the sidebar.
+1. Change the ‘All shared macros’ option to ‘2nd/3rd line--GovWiFi’.
+1. From there, you can go into each macro you want to update and edit it.
+
+If you cannot edit anything, you need to get permission. A delivery manager or the user support team will be able to sort this for you.
+
+When you add a new macro, add 2 tags:
+
+- one in the format ‘govwifi-[enduser or adminuser]-[macro description]’
+- one in the format ‘m_[the long number after the / in the page URL]’
+
+This makes sure we can track how often we use each macro over time in the [Zendesk analytics dashboard](https://govuk.zendesk.com/explore/dashboard/AB421FC5FD1465B4000E84EA293E6D67B8E0F0C275D8F0CF86CF1BEF9AC3B351).


### PR DESCRIPTION
# What

Added a new page with instructions for updating the different types of content we have.

Also adjusted the 'weight' so this page comes before the Style guide in the sidebar.

# Why

To help future GovWifi content and design people get started. 