### PR TITLE
Add secrets manager instructions and update notification docs

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -19,7 +19,7 @@ Emails are sent to the GovWifi developers mailbox. Notifications are sent to the
 
 ### AWS Cloudwatch alerts
 
-Emails are sent to GovWifi critical alerts mailbox. Notifications the #govwifi-monitoring Slack channel.
+Emails are sent to GovWifi critical alerts mailbox. Notifications are sent to the #govwifi-monitoring Slack channel.
 
 ### StatusPage alerts
 

--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -15,11 +15,11 @@ Alerts come from different sources.
 
 ### Sentry alerts
 
-Emails are sent to the GovWifi developers mailbox. Notifications are sent to the #govwifi Slack channel.
+Emails are sent to the GovWifi developers mailbox. Notifications are sent to the #govwifi-monitoring Slack channel.
 
 ### AWS Cloudwatch alerts
 
-Emails are sent to GovWifi critical alerts mailbox.
+Emails are sent to GovWifi critical alerts mailbox. Notifications the #govwifi-monitoring Slack channel.
 
 ### StatusPage alerts
 

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -1,13 +1,17 @@
 ---
 title: Get started using Secrets
 weight: 70
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-07
 review_in: 6 months
 ---
 
 # Get started using Secrets
 
-All secrets are stored in [govwifi-build][govwifi-build], and are encrypted using GPG.
+Secrets are stored in AWS Secrets Manager. You will need to be on-boarded to GovWifi's AWS accounts in order to access these secrets.
+
+Once you have access to the AWS console, navigate to the Secrets Manager service in AWS.
+
+Historically, secrets were stored in [govwifi-build][govwifi-build], and were encrypted using GPG.
 
 All shell commands assume you are running from within the [`govwifi-terraform`][govwifi-terraform]
 repository since the [govwifi-build][govwifi-build] repository is cloned in the


### PR DESCRIPTION
### What

* Update instructions for accessing secrets
* Also tweak documentation regarding alerts and notifications.

### Why

We migrated to using AWS Secrets Manager and need to indicate this in the documentation.

We've also updated where alerts go in Slack and needed to capture that in the documentation.
