### PR TITLE
Update technical documentation

### DIFF
--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploying applications
 weight: 20
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -14,7 +14,7 @@ help explain how we do it.
 
 Deploying GovWifi is done via Concourse, [hosted by GDS][gds_concourse].
 
-You will need to be part of the GovWifi team, and logged in.
+You will need to be part of the GovWifi Github team, logged in to the Concourse console via Github single sign-on, and be on the VPN.
 
 ## Core services
 
@@ -35,8 +35,9 @@ The general process is:
 
 1. Run tests.
 2. Deploy Staging.
-3. Wait for user to allow Production deploy.
-4. Deploy Production.
+3. Run the [smoke tests] (except for Frontend FreeRADIUS and Safe Restarter).
+4. Manually trigger "Confirm Deploy to <service> Production" to allow Production deploy.
+5. Deploy Production.
 
 Each service is deployed independently.
 
@@ -80,3 +81,4 @@ Each repo has it's own pipeline which deploys out to [GovPaaS][govpaas] whenever
 [product-page-repo]: https://github.com/alphagov/govwifi-product-page
 [govpaas]: https://www.cloud.service.gov.uk/
 [middleman]: https://middlemanapp.com/
+[smoke tests]: https://github.com/alphagov/govwifi-smoke-tests

--- a/source/applications/developing.html.md.erb
+++ b/source/applications/developing.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Developing applications
 weight: 10
-last_reviewed_on: 2021-04-12
+last_reviewed_on: 2021-07-13
 review_in: 3 months
 ---
 
@@ -29,7 +29,7 @@ We follow the [GDS Way for pull request best practices](https://gds-way.cloudapp
 
 Pull request titles should be pithy and under Github's 72 character limit. If the PR is a work in progress add `WIP` to the title so GitHub won't alert in the #govwifi-monitoring channel.
 
-Use this format for the pull request description:
+Complete the pull request template by adding information to the "What" and "Why" sections:
 
 ```
 ### What
@@ -45,4 +45,4 @@ Pull requests are linted and tests are run on [Concourse CI](https://cd.gds-reli
 
 ## Merging and deploying changes
 
-Once approved and merged your PR is automatically built and deployed to our staging environment where you can perform further acceptance testing. After that deploying to production is a manual step in Concourse CI.
+Once approved and merged your PR is automatically built and deployed to our staging environment where you can perform further acceptance testing and smoke testing. After that deploying to production is a manual step in Concourse CI.

--- a/source/applications/index.html.md.erb
+++ b/source/applications/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Applications
 weight: 5
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -16,16 +16,17 @@ Our public-facing websites are:
 
 Our services include:
 
-- [Frontend servers](https://github.com/alphagov/govwifi-frontend), instances of freeRADIUS that act as authentication servers
-- An [authentication API](https://github.com/alphagov/govwifi-authentication-api), which the frontend calls to help authenticate GovWifi requests
-- A [logging API](https://github.com/alphagov/govwifi-logging-api), which the frontend calls to record each GovWifi request
+- [FreeRADIUS servers](https://github.com/alphagov/govwifi-frontend), instances of FreeRADIUS that act as authentication servers (also known as the "frontend" servers)
+- An [authentication API](https://github.com/alphagov/govwifi-authentication-api), which the FreeRADIUS servers call to help authenticate GovWifi requests
+- A [logging API](https://github.com/alphagov/govwifi-logging-api), which the FreeRADIUS servers call to record each GovWifi request
 - A [user signup API](https://github.com/alphagov/govwifi-user-signup-api), which handles incoming sign-up texts and e-mails (with a little help from AWS)
 
 We manage our infrastructure via:
 
 - Terraform, see [govwifi-terraform](https://github.com/alphagov/govwifi-terraform)
-- The [safe restarter](https://github.com/alphagov/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the frontends
+- The [safe restarter](https://github.com/alphagov/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the FreeRADIUS servers
 
 Other repositories:
 
 - [Acceptance tests](https://github.com/alphagov/govwifi-acceptance-tests), which pulls together GovWifi end-to-end, from the various repositories, and runs tests against it.
+- [Smoke tests](https://github.com/alphagov/govwifi-smoke-tests), a collection of rspec with Capybara tests, using Firefox to access the live application. These smoke test the primary service journeys (authentication, sign-up, and admin site user journeys).

--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # Access the AWS console
 
-Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and then assuming your role from the GovWifi account.
+Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and then assuming your role from the GovWifi account. You must be on the VPN to access the console.
 
 Staging and Production are hosted within the same AWS account.
 

--- a/source/infrastructure/access-bastion-servers.html.md.erb
+++ b/source/infrastructure/access-bastion-servers.html.md.erb
@@ -14,15 +14,15 @@ review_in: 6 months
 - staging secret name: `keys/govwifi-staging-bastion-key`
 - production secret name: `keys/govwifi-bastion-key`
 
-Find out the Elastic IPs for the bastion servers. You can do this by going into the AWS console,
-and find the instances with the Bastion name in.
+Find out the Elastic IPs for the bastion servers. You can do this by logging into the AWS console,
+and finding the instances which contain the word "Bastion".
 
-Remember that there are 2 regions, so there may be more than 2 bastions.
+Remember there are two regions, so there may be more than two bastions.
 
 ## SSH Config
 
-It is recommended to set up an ssh config for ease of use. Instructions how to
-set up your SSH config is in the Password Store of Govwifi where you can run:
+We recommended setting up an SSH config for ease of use. Instructions how to
+set up your SSH config exist in the Password Store of GovWifi where you can run:
 
 ```sh
 PASSWORD_STORE_DIR=<password_store_dir> pass show ssh/instructions.txt
@@ -32,7 +32,7 @@ where `<password_store_dir>` is the path of the `passwords` directory of the
 [govwifi-build](https://github.com/alphagov/govwifi-build) repository on your
 local machine.
 
-You should now be able to connect to each of the hosts using ssh and the hostnames mentioned in `instructions.txt`.
+You should now be able to connect to each of the hosts using `ssh` and the hostnames mentioned in `instructions.txt`.
 
 Example:
 

--- a/source/infrastructure/access-database.html.md.erb
+++ b/source/infrastructure/access-database.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access databases
 weight: 40
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -11,7 +11,7 @@ To access each one, you will need to use their respective credentials and bastio
 
 ## Admin database
 
-This database provides for the Admin portal, storing organisation details.
+This database exists for the Admin site, storing organisation details.
 
 **AWS Naming convention**: Used for finding the database in the AWS Console
 
@@ -27,16 +27,17 @@ Connect to the admin database:
 - Production: `grep 'admin-db-username' '.private/non-encrypted/secrets-to-copy/govwifi/wifi-london/variables.auto.tfvars'`
 - Staging: `grep 'admin-db-username' '.private/non-encrypted/secrets-to-copy/govwifi/staging-london/variables.auto.tfvars'`
 
-**Password**: Get the password from the [encrypted terraform secrets][getting-a-secret]:
+**Password**: Get the password from AWS Secrets Manager:
 
-- Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars | grep admin-db-password`
-- Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/staging-london/secrets.auto.tfvars | grep admin-db-password`
+- Log in to the AWS console
+- Navigate to the Secrets Manager service
+- Search for 'RDS'
 
 Use your favourite GUI, or set up an SSH tunnel.
 
 ## Users database
 
-This database provides for the authentication service, for storing user credentials and login activity.
+This database exists for the authentication service, for storing user credentials and login activity.
 
 **AWS Naming convention**: Used for finding the database in the AWS Console
 
@@ -50,16 +51,17 @@ This database provides for the authentication service, for storing user credenti
 - Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^user-db-username"`
 - Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/staging-london/secrets.auto.tfvars  | grep -e "^user-db-username"`
 
-**Password**: Get the password from the [encrypted terraform secrets][getting-a-secret]:
+**Password**: Get the password from AWS Secrets Manager:
 
-- Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^user-db-password"`
-- Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^user-db-password"`
+- Log in to the AWS console
+- Navigate to the Secrets Manager service
+- Search for 'RDS'
 
 Use your favourite GUI, or set up an SSH tunnel.
 
 ## Sessions database
 
-This database provides for the logging service, for tracking user sessions.
+This database exists for the logging service, for tracking user sessions.
 
 **AWS Naming convention**: Used for finding the database in the AWS Console
 
@@ -73,9 +75,10 @@ This database provides for the logging service, for tracking user sessions.
 - Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^db-user"`
 - Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/staging-london/secrets.auto.tfvars  | grep -e "^db-user"`
 
-**Password**: Get the password from the [encrypted terraform secrets][getting-a-secret]:
+**Password**: Get the password from AWS Secrets Manager:
 
-- Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^db-password"`
-- Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^db-password"`
+- Log in to the AWS console
+- Navigate to the Secrets Manager service
+- Search for 'RDS'
 
 Use your favourite GUI, or set up an SSH tunnel.

--- a/source/infrastructure/add-new-aws-users.html.md.erb
+++ b/source/infrastructure/add-new-aws-users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Adding new AWS users
 weight: 10
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -9,31 +9,31 @@ review_in: 6 months
 
 You can add new AWS users to the GovWifi AWS accounts by:
 
-1. first verifying with the GovWifi developers whether to grant `admin` or `read-only` access.
+1. First verify with the GovWifi developers whether to grant `admin` or `read-only` access.
 
-1. adding the user with the appropriate privileges to the [Terraform code that describes GovWifi's account](https://github.com/alphagov/tech-ops-private/blob/master/reliability-engineering/terraform/deployments/re-govwifi/account/site.tf). You need to get the pull request approved and merged by Reliability Engineering.
+1. Add the user with the appropriate privileges to the [Terraform code that describes GovWifi's account](https://github.com/alphagov/tech-ops-private/blob/master/reliability-engineering/terraform/deployments/re-govwifi/account/site.tf). You need to get the pull request approved and merged by Reliability Engineering.
 
-1. deploying the Terraform changes by:
+1. Deploy the Terraform changes by:
 
-     a. going to the [GovWifi account directory Terraform](https://github.com/alphagov/tech-ops-private/tree/master/reliability-engineering/terraform):
+     a. Navigate to the [GovWifi account directory Terraform](https://github.com/alphagov/tech-ops-private/tree/master/reliability-engineering/terraform):
 
      ```sh
      cd terraform/deployments/re-govwifi/account/
      ```
 
-     b. using the [gds-cli](https://github.com/alphagov/gds-cli), initialise Terraform if you have not done so previously:
+     b. Using the [gds-cli](https://github.com/alphagov/gds-cli), initialise Terraform if you have not done so previously:
 
      ```sh
      gds aws govwifi -- terraform init
      ```
 
-     c. planning the Terraform project to make sure the changes are what you intend to deploy:
+     c. Run `plan` on the Terraform project to ensure the changes are what you intend to deploy:
 
      ```sh
      gds aws govwifi -- terraform plan
      ```
 
-     d. applying the Terraform changes if you are happy to proceed:
+     d. Run `apply` on the Terraform changes if you are happy to proceed:
 
      ```sh
      gds aws govwifi -- terraform apply

--- a/source/infrastructure/certificate-rotation.html.md.erb
+++ b/source/infrastructure/certificate-rotation.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: GovWifi Certificates
 weight: 90
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # GovWifi certificates
 
-We rotate the GovWifi certificate every couple of years.
+We rotate the GovWifi certificate every year.
 
 The actual rotation is handled by the SREs. 
 

--- a/source/infrastructure/database-backups.html.md.erb
+++ b/source/infrastructure/database-backups.html.md.erb
@@ -1,44 +1,18 @@
 ---
 title: Database backups
 weight: 50
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # Database backups
 
-All the GovWifi databases are backed up at 3am daily by the internal GDS build server.
-In order to connect to mysql, it has to go through the bastion server.
+GovWifi databases are automatically backed up, a process covered by the [govwifi-database-backup repo](https://github.com/alphagov/govwifi-database-backup).
 
-The script that does the backups is located in:
+This repo contains scripts used to perform the automated data export of all GovWifi MySQL databases.
 
-`/root/Scripts/govwifi-backup.sh`
+GovWifi databases are exported using `mysqldump`. The contents of the SQL dump are compressed and stored in Amazon S3.
 
-**Rotating our bastion server will cause these backups to fail with the following error**
+Backups are scheduled to run nightly and target replica instances. This is in addition to automated RDS snapshots of primary servers.
 
-*WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!*
-
-You can fix this by removing the entry from the `/root/.ssh/known_hosts` file.
-
-## SSH access requirements
-
-### VPN
-
-You need to be on a GovWifi specific VPN to gain access to this server.
-To get on this VPN, you will need to open a support request on the GDS helpdesk.
-
-### User Account
-
-Please speak to the RE-GovWifi team to get you set up on this.
-
-You will need someone with SSH access to set up your user account on the server:
-
-`useradd -m -G sudo USERNAME`
-
-You should now be able to ssh into this server:
-
-`ssh -i ~/.ssh/bob -vvvv bob@ah-govwf-d-01.dmz.gds`
-
-## Notifications
-
-To get notifications about these backups, please subscribe to the `GovWifi-DevOps` Google Group.
+The backup script runs as a scheduled container task using Amazon ECS which is configured in [govwifi-terraform](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi-api) under `database-backup-task.tf`.

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 ## Verbose Logging
 
-Starting the freeRADIUS server with the `-X` flag will enable verbose logging.
+Starting the FreeRADIUS server with the `-X` flag will enable verbose logging.
 
 This is managed through the [GovWifi Terraform][govwifi terraform link].  Due to the volume of transactions on production, enabling this may have an impact on performance.
 

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Debug FreeRADIUS
 weight: 100
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -11,7 +11,7 @@ review_in: 6 months
 
 Starting the FreeRADIUS server with the `-X` flag will enable verbose logging.
 
-This is managed through the [GovWifi Terraform][govwifi terraform link].  Due to the volume of transactions on production, enabling this may have an impact on performance.
+This is managed through the [GovWifi Terraform][govwifi terraform link].  Due to the volume of transactions on production, enabling this will have an impact on performance.
 
 A better way to use this would be to enable it on staging and to have the client who is having trouble connect to that IP.
 

--- a/source/infrastructure/free-radius/index.html.md.erb
+++ b/source/infrastructure/free-radius/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Learn about FreeRADIUS
 weight: 80
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -9,7 +9,7 @@ review_in: 6 months
 
 ## AAA
 
-GovWifi currently has a set of 6 RADIUS servers. These servers control network access with [AAA authentication](https://en.wikipedia.org/wiki/AAA_(computer_security)).
+GovWifi currently has a set of six RADIUS servers. These servers control network access with [AAA authentication](https://en.wikipedia.org/wiki/AAA_(computer_security)).
 ![Exchange with Supplicant](/images/radius_exchange.png)
 
 ### Authentication
@@ -23,9 +23,8 @@ GovWifi currently has a set of 6 RADIUS servers. These servers control network a
 
 ### Accounting
 
-- Runs on Port 1813.
-
-- While we don't block accounting requests, we don't do anything with them. If an organisation requires accounting, they can enable it on their local infrastructure.
+- Runs on Port 1813. Although port 1813 is open and running GovWifi does not perform any accounting.
+- We don't block accounting requests, but we don't do anything with them –– instead our configuration returns a NOOP. If an organisation requires accounting, they can enable it on their local infrastructure.
 
 ## Unlang
 
@@ -41,17 +40,17 @@ This way it is easier to test and change in the future.
 
 This is the software installed on our RADIUS servers.
 
-It is opensource and can be found on [Github](https://github.com/FreeRADIUS/freeradius-server).
+It is open source and can be found on [Github](https://github.com/FreeRADIUS/freeradius-server).
 
 ![FreeRADIUS server](/images/free_radius_server.png)
 
 ## The RADIUS Healthcheck
 
-The [Route53 healthcheck](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html) connects to port `3000` on a specific radius machine. For example:
+The [Route53 healthcheck](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html) connects to port `3000` on a specific FreeRADIUS servers. For example:
 ```http://12.345.678.91:3000/
 ```
 
-A ruby process listens on port `3000`. When it receives a request for `"/"`, it automatically runs an [`eapol_test`](https://github.com/alphagov/govwifi-frontend/blob/master/healthcheck/app.rb#L28) command, which then connects to the Authentication API and returns a `200` response in case a successful response is received.
+A Ruby process listens on port `3000`. When it receives a request for `"/"`, it automatically runs an [`eapol_test`](https://github.com/alphagov/govwifi-frontend/blob/master/healthcheck/app.rb#L28) command, which then connects to the Authentication API and returns a `200` response in case a successful response is received.
 
 The [configuration for the healthcheck](https://github.com/alphagov/govwifi-frontend/blob/master/healthcheck/peap-mschapv2.conf.erb) `eapol_test` can be found on GitHub.
 

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: GovWifi infrastructure
 weight: 7
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # Learn about the infrastructure
 
-This section gives an overview of the GovWifi infrastructure. A diagram of our infrastructure is available [here](https://drive.google.com/drive/u/0/folders/1G3JIDH6JOx6VUhlnx4pVIl2gOKFQThj3).
+This section gives an overview of the GovWifi infrastructure. A diagram of our infrastructure is available [on Google Drive under "GovWifi Architecture Diagram"](https://drive.google.com/drive/u/0/folders/1G3JIDH6JOx6VUhlnx4pVIl2gOKFQThj3).
 
 ## VPN
 
@@ -15,7 +15,7 @@ All connections must be made via the GDS VPN. Please contact your local service 
 
 ## Elastic IPs
 
-The Radius servers are configured to use elastic IPs (EIPs). There are six in total: three for the London AWS region and three for Ireland. Organisations which use our service allow-list these IPs and use them to connect to GovWifi.
+The RADIUS servers are configured to use elastic IPs (EIPs). There are six in total: three for the London AWS region and three for Ireland. Organisations which use our service allow-list these IPs and use them to connect to GovWifi.
 
 It is critical the EIPs do not change since this would break the configuration between organisations and our services, thereby removing organisations' access to GovWifi.
 
@@ -23,11 +23,11 @@ In order to prevent this from happening unintentionally, we configure AWS to den
 
 ## Bastions
 
-The bastion servers act as a gateway to their respective clusters + databases.
+There are two bastion servers, one per region. The bastion servers act as a gateway to the components in their respective regions and environments.
 That is to say:
 
-- To access any Staging database or server, you must access via the staging bastion.
-- To access any Production database or server, you must access via the production bastion.
+- To access any Staging database or server, you must access via the Staging bastion.
+- To access any Production database or server, you must access via the Production bastion.
 
 ## Databases
 

--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -1,17 +1,16 @@
 ---
 title: How to renew the Jenkins GPG Key
 weight: 100
-last_reviewed_on: 2021-01-25
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # How To Renew The Jenkins GPG Key
 
-If you see an error stating that this key has expired, please contact the SRE
-team. You may encounter this error when trying to re-encrypt the secrets in
-[govwifi-build](https://github.com/alphagov/govwifi-build) or in output of one of our Concourse pipelines - [such as this one](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/sync-frontend-certs).
+**Note**: GovWifi no longer uses Jenkins, the naming of the GPG key is a relic of when the team maintained a Jenkins pipeline.
 
-If you are a member of the SRE team and you are looking for further
-documentation, please see the instructions in Google Drive in the private GovWifi
-Team folder (Govwifi > Technical:developer work > Tech Docs ) entitled
-"Rotate Jenkins GPG Key".
+If you see an error stating that this key has expired, please contact the GovWifi SREs.
+
+You may encounter this error when trying to re-encrypt the secrets in [govwifi-build](https://github.com/alphagov/govwifi-build) or in output of one of our Concourse pipelines - [like the `sync-frontend-certs` pipeline](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/sync-frontend-certs).
+
+If you are a member of the SRE team and you are looking for further documentation, please review [these instructions](https://docs.google.com/document/d/16xFh1ZSAnw5o-MN5rP8BRz0701AlJ4rWXG3jY7YNWjY/edit).

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -1,23 +1,31 @@
 ---
 title: Get started using Secrets
 weight: 70
-last_reviewed_on: 2021-07-07
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
 # Get started using Secrets
 
-Secrets are stored in AWS Secrets Manager. You will need to be on-boarded to GovWifi's AWS accounts in order to access these secrets.
+Secrets are stored in AWS Secrets Manager. You will need to be on-boarded to GovWifi's AWS account in order to access these secrets.
+
+## Secrets Manager
 
 Once you have access to the AWS console, navigate to the Secrets Manager service in AWS.
 
-Historically, secrets were stored in [govwifi-build][govwifi-build], and were encrypted using GPG.
+The relevant credentials are listed in the following format: `staging/<service>/<item>` or `<service>/<item>` (credentials used in Staging contain a `staging` prefix, Production credentials don't).
+
+## Previous credential configuration
+
+Historically, secrets were stored in [govwifi-build][govwifi-build] and were encrypted using GPG.
+
+We maintain this documentation for a some remaining sensitive data which aren't critical to our Terraform or applications.
 
 All shell commands assume you are running from within the [`govwifi-terraform`][govwifi-terraform]
 repository since the [govwifi-build][govwifi-build] repository is cloned in the
 `.private` directory of [`govwifi-terraform`][govwifi-terraform].
 
-## Tools
+### Tools
 
 To use these secrets, you will need the [Password Store][passwordstore] tool installed on your machine.
 
@@ -27,7 +35,7 @@ You will also need an implementation of `gpg` installed. This will be installabl
 apt/brew/dnf/rpm/yum install gnupg
 ```
 
-## Getting access
+### Getting access
 
 Once you have installed the tools, you will need someone to re-encrypt the secrets with your public key.
 
@@ -48,7 +56,7 @@ gpg --keyserver keyserver.ubuntu.com --send-keys '<your key ID>'
 gpg --keyserver hkps.pool.sks-keyservers.net --send-keys '<your key ID>'
 ```
 
-## Giving Access
+### Giving Access
 
 The new joiner must first send their GPG key ID to a current member of the team.
 
@@ -59,7 +67,6 @@ key_id='<their key ID>'
 gpg --keyserver keyserver.ubuntu.com --receive-keys "$key_id"
 echo "${key_id}:6" | gpg --import-ownertrust
 ```
-
 
 To on-board the new GPG key, navigate to the `.private` directory in the `govwifi-terraform` project.
 
@@ -87,7 +94,7 @@ Once the secrets have been re-encrypted, use git to commit and push the changes 
 
 Raise a PR in the `govwifi-build` repo on Github. Ask another team member to test the encryption has worked by checking out the PR branch and testing they can decrypt the files using `gpg -d`.
 
-### New members 
+#### New members
 
 New members must import all the existing gpg keys that are stored.
 
@@ -98,7 +105,7 @@ all_key_ids=`cat passwords/.gpg-id`
 for key_id in $all_key_ids; do gpg --keyserver keyserver.ubuntu.com --receive-keys "$key_id"; echo "${key_id}:6" | gpg --import-ownertrust; done
 ```
 
-## Getting a secret
+### Getting a secret
 
 Throughout the documentation, there will be references to specific secrets stored within the password store.
 
@@ -127,7 +134,7 @@ PASSWORD_STORE_DIR=.private/passwords pass show keys/govwifi-staging-bastion-key
 [govwifi-terraform]: https://github.com/alphagov/govwifi-terraform
 [govwifi-build]: https://github.com/alphagov/govwifi-build
 
-## Adding/Editing a secret
+### Adding/Editing a secret
 
 Use `pass` to edit your file for ease - you can be anywhere when you do this - the <secret_name> is the dir/file path from the <password_store_dir>
 

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -19,7 +19,7 @@ The relevant credentials are listed in the following format: `staging/<service>/
 
 Historically, secrets were stored in [govwifi-build][govwifi-build] and were encrypted using GPG.
 
-We maintain this documentation for a some remaining sensitive data which aren't critical to our Terraform or applications.
+We maintain this documentation for some remaining sensitive data which aren't critical to our Terraform or applications.
 
 All shell commands assume you are running from within the [`govwifi-terraform`][govwifi-terraform]
 repository since the [govwifi-build][govwifi-build] repository is cloned in the

--- a/source/infrastructure/set-up-terraform.html.md.erb
+++ b/source/infrastructure/set-up-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up Terraform
 weight: 60
-last_reviewed_on: 2021-01-10
+last_reviewed_on: 2021-07-13
 review_in: 6 months
 ---
 
@@ -21,17 +21,19 @@ There are several prerequisites to running [govwifi-terraform](https://github.co
   ```
   [profile govwifi]
   region = eu-west-1
-  role_arn=arn:aws:iam::1234567890:role/your.name
-  mfa_serial=arn:aws:iam::1234567890:mfa/your.name@digital.cabinet-office.gov.uk
+  role_arn=arn:aws:iam::1234567890:role/first-name.last-name
+  mfa_serial=arn:aws:iam::1234567890:mfa/first-name.last-name@digital.cabinet-office.gov.uk
   ```
 
-- You've installed Terraform version `0.11.14`, this can easily be installed alongside other versions using [tfenv](https://github.com/tfutils/tfenv).
+- You've installed Terraform version declared in the [.terraform-version file](https://github.com/alphagov/govwifi-terraform/blob/master/.terraform-version). This can easily be installed alongside other versions using [tfenv](https://github.com/tfutils/tfenv).
 - (Optional) [aws-vault](https://github.com/99designs/aws-vault) is a useful AWS credential management tool. If you have other AWS credentials on you system this may help switch profiles.
-
+- (Optional) [gds-cli](https://github.com/alphagov/gds-cli) can be useful for automating some of the AWS credential management. Ask the team for help setting this up.
 
 ### Running Terraform for the first time
 
 If you are running terraform commands for the first time you'll need to initialise terraform, this involves decrypting secrets and getting the backend state from S3. This is handled by one make command:
+
+**Note**: `env` refers to `staging | staging-london | wifi | wifi-london`
 
 ```
 aws-vault exec govwifi -- make <env> init-backend

--- a/source/ways-of-working/index.html.md.erb
+++ b/source/ways-of-working/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Ways of working
 weight: 3
-last_reviewed_on: 2021-04-12
+last_reviewed_on: 2021-07-13
 review_in: 3 months
 ---
 
@@ -17,6 +17,7 @@ The main Slack channels are:
 
 - `#govwifi` - for work-related chat
 - `#govwifi-core-team` - for non-work-related things
+- `#govwifi-monitoring` - for automated alerts including pull request updates
 
 All Slack messages are deleted after 2 weeks, so put anything you might need to refer back to in an email or in a Google doc.
 


### PR DESCRIPTION
### What

Update the technical parts of our Team Manual:

* Clarify instructions
* Remove stale documentation
* Ensure hyper links work
* Add any relevant links to documentation in Google Drive
* Add new documentation that's relevant now the service has changed
* Correct typos

### Why

We are on-boarding an out-of-hours support time which will rely on our documentation to do their support. Our documentation therefore needs to be up-to-date so the team can effectively do their support


[Link to Trello card](https://trello.com/c/M34Gc5SD/1396-review-govwifi-documentation)
