### PR TITLE
Add technical documentation

### DIFF
--- a/source/infrastructure/deploy-freeradius-changes.html.md.erb
+++ b/source/infrastructure/deploy-freeradius-changes.html.md.erb
@@ -1,0 +1,44 @@
+---
+title: Deploy FreeRADIUS changes
+weight: 60
+last_reviewed_on: 2021-07-13
+review_in: 6 months
+---
+
+# Deploy FreeRADIUS changes
+
+GovWifi's implementation of FreeRADIUS is managed by the [`alphagov/govwifi-frontend`](https://github.com/alphagov/govwifi-frontend) repo.
+
+This repo generates an ECR image containing the FreeRADIUS server code which will run on ECS.
+
+Pushing these images to ECR is handled in Concourse via the [`Frontend` pipeline](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/deploy?group=Frontend) under the main `deploy` pipeline.
+
+Ensure the image has been pushed by checking that the ECS registry tags have been updated with the SHA shown in the Concourse log.
+
+## Manually restarting the ECS tasks
+
+Open ECS AWS pages for `staging-frontend-cluster` in London and Ireland in new tabs.
+
+If you deployed to production, the cluster is called `wifi-frontend-cluster`.
+
+Navigate to the "Tasks" tab on the ECS cluster page.
+
+Restart one ECS task at a time in each region by selecting the task and clicking the "Stop" button. This will stop the task and a new one will automatically be started by ECS.
+
+The newly started task will use the most recent ECS task definition as well as the most recent ECR image.
+
+Once the first set tasks have been stopped and restarted in a region, and healthchecks are green with no alarms raised, then restart the remaining three in the other region.
+
+To check the containers are healthy, navigate to the "Healthchecks" section of the Route53 AWS page and ensure all the healthchecks for each region on healthy.
+
+## Deploying certificates and keys
+
+Deploying certificates and keys is managed by the Concourse `sync-frontend-certs` pipeline which pulls from the `alphagov/govwifi-build` repo.
+
+Certificates are stored encrypted under `passwords/certs/`, and hosted in S3 buckets.
+
+All S3 buckets should contain the CA certificates.
+
+Staging buckets should hold the keys and certificates prefixed with `staging`.
+
+Production buckets should hold the keys and certificates prefixed with `wifi`.

--- a/source/infrastructure/free-radius/alerts.html.md.erb
+++ b/source/infrastructure/free-radius/alerts.html.md.erb
@@ -1,0 +1,55 @@
+---
+title: Deploying changes to FreeRADIUS
+weight: 80
+last_reviewed_on: 2021-07-13
+review_in: 6 months
+---
+
+# Common FreeRADIUS alerts
+
+## RADIUS Shared Secret is Incorrect
+
+FreeRADIUS logs an error in CloudWatch when it receives an authentication or accounting request from an IP it recognises, but the shared secret used by that IP is incorrect.
+
+This means the secret in the request does not match the secret associated with that IP in the clients list loaded at server startup.
+
+CloudWatch is configured with an alarm which monitors these log entries.
+
+An example of an alarm being raised looks like the following:
+
+> You are receiving this email because your Amazon CloudWatch Alarm
+> "Shared-secret-is-incorrect" in the EU (London) region has entered the ALARM
+> state, because "Threshold Crossed: 1 datapoint [2.0 (18/03/18 07:14:00)]
+> was greater than or equal to the threshold (1.0)." at "Monday 19 March, 2018
+> 07:14:52 UTC".
+
+It could be that the Access Point (AP) or Wireless Lan Controller (WLC) has configuration saved for a different site, so the wrong secret is added.
+
+Alternatively it could be that the organisation made a mistake when setting up their AP / WLC.
+
+In either case the organisation may not be aware of this problem until an end user reports connectivity issues to them.
+
+If this alert is in alarm state, notify the Product or Service Manager and use CloudWatch Insights to retrieve the IP of the organisation which has misconfigured its AP/WLC.
+
+## RADIUS Unknown Client
+
+FreeRADIUS logs an error when it receives an authentication or accounting request from an  IP it doesn't recognise.
+
+CloudWatch is configured with an alarm which monitors these log entries.
+
+An example of an alarm being raised looks like the following:
+
+> You are receiving this email because your Amazon CloudWatch Alarm
+> "RADIUS-unknown-client" in the EU (London) region has entered the ALARM
+> state, because "Threshold Crossed: 1 out of the last 1 datapoints [1.0
+> (19/03/18 00:13:00)] was greater than the threshold (0.0) (minimum 1
+> datapoint for OK -> ALARM transition)." at "Monday 19 March, 2018 01:13:25
+> UTC".
+
+It could be that the organisation configured the site in the last twenty-four hours, and they need to wait for FreeRADIUS to reload the site list configuration.
+
+It could alternatively be that the organisation has failed to register the site and requires prompting.
+
+An organisation may not be aware of this misconfiguration until an end user reports the problem to them.
+
+If this alert is in alarm state, notify the Product or Service Manager and use CloudWatch Insights to retrieve the IP of the organisation which has this misconfiguration.


### PR DESCRIPTION
### What

Add technical documentation migrated from `govwifi-terraform`.

### Why

Our documentation should be centralised so we have a single source of truth. This is to make it easier to on-board our out-of-hours support team who will rely more heavily on documentation. It also benefits new joiners.
