### PR TITLE
Add reset 2FA information

### DIFF
--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -49,14 +49,9 @@ With this method we can include or exclude users from other organisations, it's 
 
 ## Reset 2FA
 
-Admins can reset 2FA for other admins who are part of their organisation. 
-
-If an admin user needs to reset their 2FA:
-
-1. The admin user can ask a team member to do it for them. 
-1. The team member needs to sign into their GovWifi admin account, go to the ‘Team members’ section’ and select ‘Reset 2FA’ next to the user’s name. 
-1. The admin user can then follow the link in the email they receive, and follow the instructions to set up 2FA again. 
+Admins can reset 2FA for other admins who are part of their organisation. They can do this from the 'Team members' section of their GovWifi admin account. 
 
 If this does not work, or if the admin does not have a team member who can do this for them, we have a [manual process](https://docs.google.com/document/d/1WDG-owrxYe58GDSjkxco1u7E-EG5_t7HLCaHT2udIvw/edit#heading=h.dr97twgaw0tc). This involves the GovWifi team setting up a video call with the admin and asking to see some ID. This is to be sure it's really them trying to access GovWifi admin.
 
-There's a macro in Zendesk that you can use if an admin asks how to reset their 2FA.
+Admins may get in touch with us to ask about resetting their 2FA. There's more information about how to respond to these requests in the [Zendesk section of the Team Manual](https://govwifi-dev-docs.cloudapps.digital/zendesk-support/). 
+

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -98,3 +98,13 @@ To send them the information, use the Zendesk macro 'GovWifi - admin user - MOU 
 No. If an organisation wants to block a user, the IT team will need to do this locally.
 
 The user will still be able to access the internet using GovWifi in other buildings.
+
+## How do I reset my two factor authentication?
+
+Use the macro 'GovWifi - admin user - reset 2FA'. It explains that if an admin user needs to reset their 2FA:
+
+1. The admin user can ask a team member to do it for them. 
+1. The team member needs to sign into their GovWifi admin account, go to the ‘Team members’ section’ and select ‘Reset 2FA’ next to the user’s name. 
+1. The admin user can then follow the link in the email they receive, and follow the instructions to set up 2FA again. 
+
+The macro also explains that if this does not work, or if the admin does not have a team member who can do this for them, we have a [manual process](https://docs.google.com/document/d/1WDG-owrxYe58GDSjkxco1u7E-EG5_t7HLCaHT2udIvw/edit#heading=h.dr97twgaw0tc). This involves us setting up a video call with the admin and asking to see some ID. This is to be sure it's really them trying to access GovWifi admin. The process document includes more information about how do to this check.

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -95,7 +95,7 @@ To send them the information, use the Zendesk macro 'GovWifi - admin user - MOU 
 
 ## Can you block a user on our network?
 
-No. If an organisation wants to block a user, the IT team will need to do this locally.
+No. If an organisation wants to block a user, its IT team will need to do this locally.
 
 The user will still be able to access the internet using GovWifi in other buildings.
 


### PR DESCRIPTION
### What
Add info about resetting 2FA

### Why
So team members can easily find information about the process when they get a ticket about it in Zendesk. 
