### PR TITLE
Add instructions to use the gds-cli to access AWS console

### DIFF
--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: 2021-07-13
+last_reviewed_on: 2021-08-20
 review_in: 6 months
 ---
 
@@ -12,3 +12,22 @@ Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and 
 Staging and Production are hosted within the same AWS account.
 
 The GovWifi Account ID is `788375279931` and your role is in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
+
+
+## Use the `gds-cli`
+
+You can also use the [`gds-cli`](https://github.com/alphagov/gds-cli) to access the GovWifi AWS console.
+
+Review the [configuration instructions](https://github.com/alphagov/gds-cli#configuration) on the `gds-cli` README to set it up.
+
+Once the `gds-cli` is set up, run the following command from anywhere in your terminal to login as `read-only`:
+
+```bash
+$ gds aws govwifi-readonly -l
+```
+
+If you have admin privileges in AWS, you can run a similar command to login as `admin`:
+
+```bash
+$ gds aws govwifi -l
+```

--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -14,7 +14,7 @@ Staging and Production are hosted within the same AWS account.
 The GovWifi Account ID is `788375279931` and your role is in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
 
 
-## Use the `gds-cli`
+### Use the `gds-cli`
 
 You can also use the [`gds-cli`](https://github.com/alphagov/gds-cli) to access the GovWifi AWS console.
 


### PR DESCRIPTION
### What

Add instructions to use the `gds-cli` to access AWS console.

### Why

Many of our day-to-day pairing interactions assume the use of the `gds-cli` and it would be helpful to point new joiners in this direction.