### PR TITLE
Adding a section about BCP and DR plans for the service.

### DIFF
--- a/source/incidents-and-alerts/bcp_and_dr.html.md.erb
+++ b/source/incidents-and-alerts/bcp_and_dr.html.md.erb
@@ -7,7 +7,7 @@ review_in: 6 months
 
 # Business Continuity and Disaster Recovery management
 
-This section outlines Business Continuity Plans (BCP) and Disaster Recovery (DR) agreements and documentation available for GovWifi service. BCP and DR documentation is stored within [team drive] (https://drive.google.com/drive/folders/1QyB1M-5bwh392_7IKcsMmKuYSGxm5KPG) and is created to supports existing P1 procedures and comms. 
+This section outlines Business Continuity Plans (BCP) and Disaster Recovery (DR) agreements and documentation available for GovWifi service. BCP and DR documentation is stored within [team drive](https://drive.google.com/drive/folders/1QyB1M-5bwh392_7IKcsMmKuYSGxm5KPG) and is created to supports existing P1 procedures and comms. 
 
 ## Strategy for dealing with outages
 
@@ -22,16 +22,16 @@ The Product Manager decides when to invoke internal BCP procedures and migrate f
 
 ## Documentation
 
-Business Continuity and Disaster Recovery [document] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.s3ahq5rjxmsb) is a primary reference for:
+Business Continuity and Disaster Recovery [document](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.s3ahq5rjxmsb) is a primary reference for:
 
-- Existing support agreements and escalation paths for [AWS services] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.katisw9fie2v), [GOV.UK Notify] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8d1louy3x30f) and [GitHub] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.ou435h6kidhg).
-- [Communication templates] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8f7ezrd8yzce) pre-configured within Status.io and GOV.UK Notify to support region level outages
-- [Service dependencies] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.gjyoz5ghmx3x) along with possible scenarios, agreed timelines and steps required to bring service online and restore after a disaster.
+- Existing support agreements and escalation paths for [AWS services](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.katisw9fie2v), [GOV.UK Notify](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8d1louy3x30f) and [GitHub](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.ou435h6kidhg).
+- [Communication templates](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8f7ezrd8yzce) pre-configured within Status.io and GOV.UK Notify to support region level outages
+- [Service dependencies](https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.gjyoz5ghmx3x) along with possible scenarios, agreed timelines and steps required to bring service online and restore after a disaster.
 
 Other essential documents to support BCP and DR plan are:
 
-- [GovWifi service playbook] (https://docs.google.com/document/d/1TBmLiM7y1o3lYPTHMZ-r64riRslZ9htiVdOXlw43X3M/edit#heading=h.54lyfbwz0rjj) - common troubleshooting steps helpful during P1-P3 incidents
-- [GovWifi data recovery playbook] (https://docs.google.com/document/d/1h07adu7Ym6yN4kULbDskHQO91LhHpKMFSi4wxyZi1zs/edit#heading=h.4od9neuh1vw0) - procedures required to recover GovWifi datasets from onsite and offsite backups
+- [GovWifi service playbook](https://docs.google.com/document/d/1TBmLiM7y1o3lYPTHMZ-r64riRslZ9htiVdOXlw43X3M/edit#heading=h.54lyfbwz0rjj) - common troubleshooting steps helpful during P1-P3 incidents
+- [GovWifi data recovery playbook](https://docs.google.com/document/d/1h07adu7Ym6yN4kULbDskHQO91LhHpKMFSi4wxyZi1zs/edit#heading=h.4od9neuh1vw0) - procedures required to recover GovWifi datasets from onsite and offsite backups
 
 
 

--- a/source/incidents-and-alerts/bcp_and_dr.html.md.erb
+++ b/source/incidents-and-alerts/bcp_and_dr.html.md.erb
@@ -1,0 +1,40 @@
+---
+title: Business Continuity and Disaster Recovery management
+weight: 30
+last_reviewed_on: 2021-08-24
+review_in: 6 months
+---
+
+# Business Continuity and Disaster Recovery management
+
+This section outlines Business Continuity Plans (BCP) and Disaster Recovery (DR) agreements and documentation available for GovWifi service. BCP and DR documentation is stored within [team drive] (https://drive.google.com/drive/folders/1QyB1M-5bwh392_7IKcsMmKuYSGxm5KPG) and is created to supports existing P1 procedures and comms. 
+
+## Strategy for dealing with outages
+
+- Rely on a resilient architecture
+- Triage and fix the service if possible
+- Migrate faulty services to a secondary region if the primary region is offline
+- Complete environment rebuild in the new AWS account
+
+## Service ownership and decision-makers
+
+The Product Manager decides when to invoke internal BCP procedures and migrate faulty service or recover environmnet in the new region. In his absence, Technical Lead, Infrastructure Lead and Technical Architect can make this decision.
+
+## Documentation
+
+Business Continuity and Disaster Recovery [document] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.s3ahq5rjxmsb) is a primary reference for:
+
+- Existing support agreements and escalation paths for [AWS services] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.katisw9fie2v), [GOV.UK Notify] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8d1louy3x30f) and [GitHub] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.ou435h6kidhg).
+- [Communication templates] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.8f7ezrd8yzce) pre-configured within Status.io and GOV.UK Notify to support region level outages
+- [Service dependencies] (https://docs.google.com/document/d/1apIQNw7HYLBi0kdlRSvkKfFazFJaQKi_08vlQfw2pz0/edit#heading=h.gjyoz5ghmx3x) along with possible scenarios, agreed timelines and steps required to bring service online and restore after a disaster.
+
+Other essential documents to support BCP and DR plan are:
+
+- [GovWifi service playbook] (https://docs.google.com/document/d/1TBmLiM7y1o3lYPTHMZ-r64riRslZ9htiVdOXlw43X3M/edit#heading=h.54lyfbwz0rjj) - common troubleshooting steps helpful during P1-P3 incidents
+- [GovWifi data recovery playbook] (https://docs.google.com/document/d/1h07adu7Ym6yN4kULbDskHQO91LhHpKMFSi4wxyZi1zs/edit#heading=h.4od9neuh1vw0) - procedures required to recover GovWifi datasets from onsite and offsite backups
+
+
+
+
+
+

--- a/source/incidents-and-alerts/team-dashboard.html.md.erb
+++ b/source/incidents-and-alerts/team-dashboard.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Team dashboards
-weight: 10
+weight: 20
 last_reviewed_on: 2021-04-08
 review_in: 6 months
 ---


### PR DESCRIPTION
### What
We want to make our internal BCP and DR plans visible

### Why
so the team working on the BCP and DR incident have a well-known point of reference for existing documentation.

