### PR TITLE
Secrets link is broken and is an H1 so no tag required

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -86,7 +86,7 @@ You need access to the `GovWifi-DevOps` Google group.
 
 ### Secrets
 
-You need to [get access to shared secrets](/infrastructure/secrets/#get-started-using-secrets).
+You need to [get access to shared secrets](/infrastructure/secrets.html).
 
 ### Monitoring tools
 


### PR DESCRIPTION
### What
Let's fix the link to getting started with secrets for new joiners and remove the need for a tag.

### Why
The original link is broken and the link points at an H1 tag so no further linking is required.

### Testing
This can be tested locally by following the README.md instructions for local testing.

