### PR TITLE
Add environment documentation

### DIFF
--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: 2021-08-20
+last_reviewed_on: 2021-09-21
 review_in: 6 months
 ---
 
@@ -9,10 +9,9 @@ review_in: 6 months
 
 Access is via [gds-users](https://gds-users.signin.aws.amazon.com/console), and then assuming your role from the GovWifi account. You must be on the VPN to access the console.
 
-Staging and Production are hosted within the same AWS account.
+Staging and Production are hosted in different AWS accounts.
 
-The GovWifi Account ID is `788375279931` and your role is in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
-
+Ask the reliability engineers for the GovWifi account IDs. AWS roles are in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
 
 ### Use the `gds-cli`
 
@@ -20,14 +19,20 @@ You can also use the [`gds-cli`](https://github.com/alphagov/gds-cli) to access 
 
 Review the [configuration instructions](https://github.com/alphagov/gds-cli#configuration) on the `gds-cli` README to set it up.
 
-Once the `gds-cli` is set up, run the following command from anywhere in your terminal to login as `read-only`:
+Once the `gds-cli` is set up, run the following command from anywhere in your terminal to login as `read-only` to Production:
 
 ```bash
 $ gds aws govwifi-readonly -l
 ```
 
-If you have admin privileges in AWS, you can run a similar command to login as `admin`:
+If you have admin privileges in the Production AWS account, you can run a similar command to login as `admin`:
 
 ```bash
 $ gds aws govwifi -l
+```
+
+You can login as `admin` to Staging by running the following command:
+
+```
+$ gds aws govwifi-staging -l
 ```

--- a/source/infrastructure/access-bastion-servers.html.md.erb
+++ b/source/infrastructure/access-bastion-servers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access bastion servers
 weight: 30
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2021-09-22
 review_in: 6 months
 ---
 
@@ -11,13 +11,11 @@ review_in: 6 months
 
 [Extract the SSH Key secrets](/infrastructure/secrets/#get-started-using-secrets) for the bastion server:
 
-- staging secret name: `keys/govwifi-staging-bastion-key`
+- staging secret name: `keys/govwifi-staging-temp-bastion-key-20200717`
 - production secret name: `keys/govwifi-bastion-key`
 
 Find out the Elastic IPs for the bastion servers. You can do this by logging into the AWS console,
 and finding the instances which contain the word "Bastion".
-
-Remember there are two regions, so there may be more than two bastions.
 
 ## SSH Config
 

--- a/source/infrastructure/access-database.html.md.erb
+++ b/source/infrastructure/access-database.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access databases
 weight: 40
-last_reviewed_on: 2021-07-13
+last_reviewed_on: 2021-09-22
 review_in: 6 months
 ---
 
@@ -22,12 +22,7 @@ Connect to the admin database:
 
 **Endpoint**: View in the AWS Console
 
-**Username**: View in the AWS Console, or the terraform config.
-
-- Production: `grep 'admin-db-username' '.private/non-encrypted/secrets-to-copy/govwifi/wifi-london/variables.auto.tfvars'`
-- Staging: `grep 'admin-db-username' '.private/non-encrypted/secrets-to-copy/govwifi/staging-london/variables.auto.tfvars'`
-
-**Password**: Get the password from AWS Secrets Manager:
+**Username** and **Password**: View the password in AWS Secrets Manager:
 
 - Log in to the AWS console
 - Navigate to the Secrets Manager service
@@ -46,12 +41,7 @@ This database exists for the authentication service, for storing user credential
 
 **Endpoint**: View in the AWS Console.
 
-**Username**: View in the AWS Console, or [the terraform config][getting-a-secret].
-
-- Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^user-db-username"`
-- Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/staging-london/secrets.auto.tfvars  | grep -e "^user-db-username"`
-
-**Password**: Get the password from AWS Secrets Manager:
+**Username** and **Password**: View the password in AWS Secrets Manager:
 
 - Log in to the AWS console
 - Navigate to the Secrets Manager service
@@ -70,12 +60,7 @@ This database exists for the logging service, for tracking user sessions.
 
 **Endpoint**: View in the AWS Console.
 
-**Username**: View in the AWS Console, or [the terraform config][getting-a-secret].
-
-- Production: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/wifi-london/secrets.auto.tfvars  | grep -e "^db-user"`
-- Staging: `PASSWORD_STORE_DIR=.private/passwords pass show secrets-to-copy/govwifi/staging-london/secrets.auto.tfvars  | grep -e "^db-user"`
-
-**Password**: Get the password from AWS Secrets Manager:
+**Username** and **Password**: View the password in AWS Secrets Manager:
 
 - Log in to the AWS console
 - Navigate to the Secrets Manager service

--- a/source/infrastructure/deploy-terraform.html.md.erb
+++ b/source/infrastructure/deploy-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy Terraform
 weight: 60
-last_reviewed_on: 2021-09-15
+last_reviewed_on: 2021-09-21
 review_in: 6 months
 ---
 
@@ -21,3 +21,72 @@ The instructions here provide a high level overview of deploying changes in our 
 |             | Ireland | staging-dublin-temp | 99**********        |
 | Production  | London  | wifi-london         | 78**********        |
 |             | Ireland | wifi                | 78**********        |
+
+**Note**
+
+Our secondary AWS account used for staging includes the suffix `temp`. This was to avoid a naming conflict with our staging components that previously existed in the primary AWS account.
+
+It will be changed in the future.
+
+## Prerequisites
+
+These must be complete in order to deploy Terraform changes:
+
+* On-boarded to GovWifi's AWS account
+* AWS credentials set up on laptop
+
+It's recommended but not required to use the [`gds-cli`](https://github.com/alphagov/gds-cli).
+
+## Deploy to Staging
+
+Deployments in `govwifi-terraform` pull in changes using modules configured in the `main.tf` file located in `govwifi` sub-directory.
+
+For staging, these are:
+
+* [`govwifi/staging-london-temp`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/staging-london-temp)
+* [`govwifi/staging-dublin-temp`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/staging-dublin-temp)
+
+To deploy Terraform changes to the staging environment, navigate to the project root:
+
+```
+$ cd govwifi-terraform
+```
+
+Ensure the branch is up-to-date by pulling the latest changes from git (`git pull`).
+
+Run the relevant `make` command, pointing to the desired staging environment and region:
+
+```
+$ make staging-london-temp plan
+```
+
+If you are using the `gds-cli`, use to the staging GovWifi account:
+
+```
+$ gds aws govwifi-staging -- make staging-london-temp plan
+```
+
+## Deploy to production
+
+The deploy process is very similar to staging.
+
+The production modules in `govwifi-terraform` are:
+
+* [`govwifi/wifi-london`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/wifi-london)
+* [`govwifi/wifi`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/wifi)
+
+**Note**: `wifi` refers to components in eu-west-1 (Ireland).
+
+Follow the same instructions for staging (i.e., navigate to the root project directory and ensure the branch is up-to-date).Ireland
+
+The `make` command for production is:
+
+```
+$ make wifi-london plan
+```
+
+If using the `gds-cli` it's:
+
+```
+$ gds aws govwifi -- make wifi-london plan
+```

--- a/source/infrastructure/deploy-terraform.html.md.erb
+++ b/source/infrastructure/deploy-terraform.html.md.erb
@@ -1,0 +1,23 @@
+---
+title: Deploy Terraform
+weight: 60
+last_reviewed_on: 2021-09-15
+review_in: 6 months
+---
+
+# Deploy Terraform
+
+Terraform is deployed on the commandline using `make` commands configured in the `govwifi-terraform` [Makefile](https://github.com/alphagov/govwifi-terraform/blob/master/Makefile).
+
+Please refer to the `govwifi-terraform` [README](https://github.com/alphagov/govwifi-terraform/blob/master/README.md) for detailed instructions on running Terraform.
+
+The instructions here provide a high level overview of deploying changes in our Terraform
+
+**Environments**
+
+| Environment |  Region |         Name        |  AWS Account        |
+|:-----------:|:-------:|:-------------------:|:-------------------:|
+| Staging     | London  | staging-london-temp | 99**********        |
+|             | Ireland | staging-dublin-temp | 99**********        |
+| Production  | London  | wifi-london         | 78**********        |
+|             | Ireland | wifi                | 78**********        |

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi infrastructure
 weight: 7
-last_reviewed_on: 2021-07-13
+last_reviewed_on: 2021-09-21
 review_in: 6 months
 ---
 

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -9,6 +9,10 @@ review_in: 6 months
 
 This section gives an overview of the GovWifi infrastructure. A diagram of our infrastructure is available [on Google Drive under "GovWifi Architecture Diagram"](https://drive.google.com/drive/u/0/folders/1G3JIDH6JOx6VUhlnx4pVIl2gOKFQThj3).
 
+## Environments
+
+GovWifi has two environments in separate AWS accounts: Staging and Production.
+
 ## VPN
 
 All connections must be made via the GDS VPN. Please contact your local service desk for access.

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -1,19 +1,19 @@
 ---
 title: Get started using Secrets
 weight: 70
-last_reviewed_on: 2021-07-13
+last_reviewed_on: 2021-09-21
 review_in: 6 months
 ---
 
 # Get started using Secrets
 
-Secrets are stored in AWS Secrets Manager. You will need to be on-boarded to GovWifi's AWS account in order to access these secrets.
+Secrets are stored in AWS Secrets Manager. You will need to be on-boarded to GovWifi's AWS Staging and Production accounts in order to access these secrets.
 
 ## Secrets Manager
 
 Once you have access to the AWS console, navigate to the Secrets Manager service in AWS.
 
-The relevant credentials are listed in the following format: `staging/<service>/<item>` or `<service>/<item>` (credentials used in Staging contain a `staging` prefix, Production credentials don't).
+The relevant credentials are listed in the following format: `<service>/<item>`.
 
 ## Previous credential configuration
 


### PR DESCRIPTION
### What

Update relevant documentation to include information about the secondary AWS account dedicated to staging.

### Why

We've separated our environments into different AWS accounts and this needs to be reflected in the documentation.


Link to [Trello card](https://trello.com/c/YK5KJgDs/1583-story-share-knowledge-about-secondary-staging-environment).
