### PR TITLE
Update incident management content and last reviewed date

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Incident management
 weight: 8
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2021-10-25
 review_in: 3 months
 ---
 
@@ -37,7 +37,7 @@ Emails are sent to the GovWifi support mailbox and StatusPage.
 
 1. Share a brief summary of what you’ve seen on the #govwifi Slack channel.
 2. Find out if anyone else is already investigating the issue.
-3. If the issue is security related, tell the Cyber Security Team. You can use the #cyber-security-help Slack channel or the [GDS Rotas app](https://rotas.cloudapps.digital/).
+3. If the issue is security related, tell the Cyber Security Team. You can use the #cyber-security-help Slack channel.
 
 ## Appoint an incident lead
 
@@ -184,7 +184,7 @@ Emotions are likely to be running high for the incident team. This can lead to m
 
 ### Consider the interoperability of unified communications tools
 
-GovWifi uses Google Meet, other organisations may not use Google Meet. If the unified comms does not work for either team. Screen shares can be incredibly helpful to both teams so try and find one that works for everyone.
+GovWifi uses Google Meet, other organisations may not use Google Meet. If the unified comms does not work for either team try and find one that works for everyone. Screen shares can be incredibly helpful to both teams so finding a common platform is important.
 
 ### Be confident in your knowledge of GovWifi
 


### PR DESCRIPTION
### What

* Remove stale link that results in a 404, the GDS Rotas app appears to be no more (it was replaced by PagerDuty).
* Correct incomplete sentence.

### Why

Our documentation needs to remain fresh. Stale documentation is not useful.


Link to Trello card (if applicable): https://trello.com/c/12o7KHBA/1749-update-incident-management-dev-docs
