### PR TITLE
Remove some redundant tech-ops references in the pipeline

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -18,11 +18,6 @@ resource_types:
     password: ((docker_hub_authtoken))
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-dev-docs
     type: git
     source:
@@ -49,9 +44,6 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-dev-docs
       trigger: true
     - set_pipeline: self


### PR DESCRIPTION
### What
Remove some redundant tech-ops references in the pipeline

### Why
The tech-ops repository was used for setting the pipeline, which is
now done with the builtin feature.
