### PR TITLE
Updated links to email addresses

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -32,13 +32,13 @@ We know some parts of this website are not fully accessible for the following re
 
 ## Feedback and contact information
 
-If you need any part of this service in a different format like large print, audio recording or braille, email [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
+If you need any part of this service in a different format like large print, audio recording or braille, email [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk).
 
 We’ll consider your request and get back to you within 2 working days.
 
 ## Reporting accessibility problems with this website
 
-We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govwifi-support@digital.cabinet-office.gov.uk](govwifi-support@digital.cabinet-office.gov.uk).
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [govwifi-support@digital.cabinet-office.gov.uk](mailto:govwifi-support@digital.cabinet-office.gov.uk).
 
 ### Enforcement procedure
 


### PR DESCRIPTION
### What
Hyperlinks to email addresses needs to be updated as `mailto:` is missing.

### Why
Right now, "404 Not Found" is presented when links are used.


Link to Trello card (if applicable): 

https://trello.com/c/EX3E5orE/1764-zendesk-govwifi-support10138-hello-from-the-caribbean