### PR TITLE
Update staging url

### DIFF
--- a/source/infrastructure/free-radius/index.html.md.erb
+++ b/source/infrastructure/free-radius/index.html.md.erb
@@ -58,7 +58,7 @@ If you need to manually test the healthcheck in a radius docker container you ca
 ```eapol_test -c /usr/src/healthcheck/peap-mschapv2.conf -s $(echo $HEALTH_CHECK_RADIUS_KEY)
 ```
 
-The secret can also be found by logging in as a GovWifi administrator( for staging you would login [here](https://admin.staging.wifi.service.gov.uk/) ), switching to the GDS CTS organisation, then selecting “Locations” and scrolling to “Health check user”
+The secret can also be found by logging in as a GovWifi administrator (for staging you would login [here](https://admin.staging-temp.wifi.service.gov.uk/) ), switching to the GDS CTS organisation, then selecting “Locations” and scrolling to “Health check user”.
 
 It should also be noted that the last login of the health check user is no longer recorded in the User database.
 

--- a/source/update-govwifi-content.html.md.erb
+++ b/source/update-govwifi-content.html.md.erb
@@ -64,7 +64,7 @@ There’s a [Google data studio dashboard](https://datastudio.google.com/reporti
 
 GovWifi admin is where admin users can set up GovWifi for their organisation and view user logs.
 
-This is [GovWifi admin (production)](https://admin.wifi.service.gov.uk/users/sign_in). This is [GovWifi admin (staging)](https://admin.staging.wifi.service.gov.uk/users/sign_in).
+This is [GovWifi admin (production)](https://admin.wifi.service.gov.uk/users/sign_in). This is [GovWifi admin (staging)](https://admin.staging-temp.wifi.service.gov.uk/users/sign_in).
 
 Here’s the [GovWifi admin repo](https://github.com/alphagov/govwifi-admin). It’s written in Ruby.
 


### PR DESCRIPTION
### What

Point to the `admin.staging-temp.wifi` URL instead of the decommissioned `admin.staging.wifi` URL.

### Why

The previous URL was running in the primary AWS account where we've decommissioned staging components. We now have a dedicated AWS account for staging where the staging admin app is running.

We need to update the documentation to point to the in-use URL.
