### PR TITLE
Update documentation

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GovWifi Team Manual
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 hide_in_navigation: true
 ---

--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Team Manual
 weight: 1
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 ---
 

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get started on the team
 weight: 4
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 ---
 
@@ -55,7 +55,7 @@ You should have access to:
 You should be in these Google groups:
 
 - GovWifi Core Team
-- Govwifi-support
+- GovWifi-support
 
 You should be in these Slack channels:
 
@@ -88,10 +88,10 @@ You need access to the `GovWifi-DevOps` Google group.
 
 You need to [get access to shared secrets](/infrastructure/secrets.html).
 
-### Monitoring tools
+### Monitoring and CI/CD tools
 
 You need access to:
 
-- [Concourse](https://cd.gds-reliability.engineering/)
+- [Concourse](https://govwifi-cd.wifi.service.gov.uk/)
 - [Sentry SaaS](https://sentry.io/organizations/government-digital-services/projects/)
 - Alerts and logs in [Cloudwatch](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#)

--- a/source/get-started/leavers.html.md.erb
+++ b/source/get-started/leavers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Leaving
 weight: 10
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 ---
 
@@ -51,11 +51,11 @@ Remove them from the `GovWifi-DevOps` Google group.
 
 ### Secrets
 
-Their access to secrets would need to be removed.
+Their access to secrets will need to be removed.
 
 ### Monitoring tools
 
 Their access to these should be removed:
 
-- [Concourse](https://cd.gds-reliability.engineering/)
+- [Concourse](https://govwifi-cd.wifi.service.gov.uk/)
 - [Grafana](https://grafana-paas.cloudapps.digital/?orgId=4)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Team Manual
 weight: 1
-last_reviewed_on: 2021-08-10
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 ---
 

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Zendesk
 weight: 9
-last_reviewed_on: 2021-07-21
+last_reviewed_on: 2022-01-21
 review_in: 6 months
 ---
 


### PR DESCRIPTION
### What

* update `last_reviewed_on` date
* add correct link to GovWifi Concourse (Big Concourse was decommissioned)
* fix typo

### Why

Ensure our documentation reflects current practises and our environments.