### PR TITLE
Add link to RADIUS authentication troubleshooting questions

### DIFF
--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -116,3 +116,5 @@ Use the macro 'Govwifi - admin user - end users having connection issues' when a
 If they continue to report issues, use the ["Questions for organisations facing RADIUS authentication issues"](https://docs.google.com/document/d/1_3OhChrYwd-ByuC4yJfqp0iTtlKKX9Uw_x77BJJhITw) document to develop a list of questions for the admin user to answer.
 
 The more we know about the issue the better able we are to investigate.
+
+If the organisation is experiencing an incident, regardless of whether the root cause is GovWifi or not, we recommend following the steps outlined in ["Helping other organisation incident management teams with their incidents"](https://docs.google.com/document/d/1eO6eNtks-k3rW4KWXIMctlVHV5vqD8hN5SUM_jO4biM/).

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -108,3 +108,11 @@ Use the macro 'GovWifi - admin user - reset 2FA'. It explains that if an admin u
 1. The admin user can then follow the link in the email they receive, and follow the instructions to set up 2FA again. 
 
 The macro also explains that if this does not work, or if the admin does not have a team member who can do this for them, we have a [manual process](https://docs.google.com/document/d/1WDG-owrxYe58GDSjkxco1u7E-EG5_t7HLCaHT2udIvw/edit#heading=h.dr97twgaw0tc). This involves us setting up a video call with the admin and asking to see some ID. This is to be sure it's really them trying to access GovWifi admin. The process document includes more information about how do to this check.
+
+## My organisation is having connectivity issues
+
+Use the macro 'Govwifi - admin user - end users having connection issues' when an admin users reports connection issues.
+
+If they continue to report issues, use the ["Questions for organisations facing RADIUS authentication issues"](https://docs.google.com/document/d/1_3OhChrYwd-ByuC4yJfqp0iTtlKKX9Uw_x77BJJhITw) document to develop a list of questions for the admin user to answer.
+
+The more we know about the issue the better able we are to investigate.


### PR DESCRIPTION
### What

Create a section and instructions specifically for admin users raising connectivity issues.
Also link to the Google doc which contains some useful troubleshooting questions for admin users.

### Why

Make it clear for the person on support how they should respond to admin user queries about connectivity. Also ensure we're signposting to the troubleshooting questions.