### PR TITLE
Update the Terraform related documentation for staging consolidation

### DIFF
--- a/source/infrastructure/deploy-terraform.html.md.erb
+++ b/source/infrastructure/deploy-terraform.html.md.erb
@@ -17,8 +17,8 @@ The instructions here provide a high level overview of deploying changes in our 
 
 | Environment |  Region |         Name        |  AWS Account        |
 |:-----------:|:-------:|:-------------------:|:-------------------:|
-| Staging     | London  | staging-london      | 99**********        |
-|             | Ireland | staging-dublin      | 99**********        |
+| Staging     | London  | staging             | 99**********        |
+|             | Ireland | (also staging)      | 99**********        |
 | Production  | London  | wifi-london         | 78**********        |
 |             | Ireland | wifi                | 78**********        |
 
@@ -33,12 +33,11 @@ It's recommended but not required to use the [`gds-cli`](https://github.com/alph
 
 ## Deploy to Staging
 
-Deployments in `govwifi-terraform` pull in changes using modules configured in the `main.tf` file located in `govwifi` sub-directory.
+Deployments in `govwifi-terraform` pull in changes using modules
+configured in the Terraform files located in `govwifi/staging`
+directory:
 
-For staging, these are:
-
-* [`govwifi/staging-london`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/staging-london)
-* [`govwifi/staging-dublin`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/staging-dublin)
+* [`govwifi/staging`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi/staging)
 
 To deploy Terraform changes to the staging environment, navigate to the project root:
 
@@ -48,16 +47,16 @@ $ cd govwifi-terraform
 
 Ensure the branch is up-to-date by pulling the latest changes from git (`git pull`).
 
-Run the relevant `make` command, pointing to the desired staging environment and region:
+Run the relevant `make` command:
 
 ```
-$ make staging-london plan
+$ make staging plan
 ```
 
 If you are using the `gds-cli`, use to the staging GovWifi account:
 
 ```
-$ gds aws govwifi-staging -- make staging-london plan
+$ gds aws govwifi-staging -- make staging plan
 ```
 
 ## Deploy to production

--- a/source/infrastructure/set-up-terraform.html.md.erb
+++ b/source/infrastructure/set-up-terraform.html.md.erb
@@ -33,7 +33,7 @@ There are several prerequisites to running [govwifi-terraform](https://github.co
 
 If you are running terraform commands for the first time you'll need to initialise terraform, this involves decrypting secrets and getting the backend state from S3. This is handled by one make command:
 
-**Note**: `env` refers to `staging | staging-london | wifi | wifi-london`
+**Note**: `env` refers to `staging | wifi | wifi-london`
 
 ```
 aws-vault exec govwifi -- make <env> init-backend


### PR DESCRIPTION
### What
Update the Terraform related documentation for staging consolidation

### Why
Keeping the documentation up to date is good.


Link to Trello card: https://trello.com/c/HublU99C/2065-remove-necessity-to-specify-a-region-when-running-govwifi-terraform