### PR TITLE
Add information about the Google Cloud Platform

### DIFF
--- a/source/infrastructure/access-gcp-components.md.erb
+++ b/source/infrastructure/access-gcp-components.md.erb
@@ -1,0 +1,17 @@
+---
+title: Access Google Cloud Platfrom (GCP) components
+weight: 90
+last_reviewed_on: 2022-05-12
+review_in: 6 months
+---
+
+# Google Cloud Platform (GCP)
+
+The GovWifi team does not run production workloads within the GCP but some service components rely on the integration with GCP as an interface to Google resources.
+
+GCP is used in the context of:
+- Single Sign-On authentication to Grafana servers
+- access to Gmail functionality on the application level, used by smoke tests
+- access to Google Drive resources, used to store backups of Organisation Emails
+
+For details of GCP projects attributed to the GovWifi service (at various development stages), current owners and how to access and find configured resources please refer to the [GCP Projects review](https://docs.google.com/spreadsheets/d/1B0uo92ZXqCEJqZzgdQY1ncq9nohKDTS-7SJwueMgieM/) document. 


### PR DESCRIPTION
### What
Add a new section about the `Google Cloud Platform` and its role within the GovWifi service. 

### Why
Components of the GovWifi service rely on the integration with some Google resources accessed via the GCP integration. 

We've captured GCP project attributed to the GovWifi service and linked results within the Developer website so team members can check details like project owner and discovered components if required.

Link to Trello card:
https://trello.com/c/apNBJ1jP/1997-review-and-document-govwifi-google-cloud-platform-projects 
