### PR TITLE
Add a Monitoring and instrumentation page

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -85,7 +85,7 @@ jobs:
               curl -sL https://deb.nodesource.com/setup_14.x | bash -
               apt-get install -y nodejs
               bundle install --without development
-              bundle exec middleman build
+              bundle exec middleman build --verbose
     on_success:
       put: govwifi-dev-docs-pr
       params:

--- a/source/applications/monitoring-and-instrumentation.html.md.erb
+++ b/source/applications/monitoring-and-instrumentation.html.md.erb
@@ -1,0 +1,19 @@
+---
+title: Monitoring and instrumentation
+weight: 20
+last_reviewed_on: 2022-07-18
+review_in: 6 months
+---
+
+# Monitoring and instrumentation
+
+Generally, this is done with the AWS tooling. There is information in
+ECS about resource usage, and further information in Cloudwatch.
+
+## Admin app
+
+Additionally, requests that pass through the load balancer for the
+Admin app are recorded in an S3 bucket.
+
+These logs are queryable through AWS Athena, for example to find
+requests that resulted in a 504 response.


### PR DESCRIPTION
### What
Add a Monitoring and instrumentation page

### Why
Mostly as I want to point out the access logging available for the
Admin app.


Link to Trello card: https://trello.com/c/edOh8QZf/2360-setup-alerting-for-5xx-errors-in-admin-site