### PR TITLE
Add reference to Google Analytics/Datastudio

### DIFF
--- a/source/applications/index.html.md.erb
+++ b/source/applications/index.html.md.erb
@@ -30,3 +30,10 @@ Other repositories:
 
 - [Acceptance tests](https://github.com/alphagov/govwifi-acceptance-tests), which pulls together GovWifi end-to-end, from the various repositories, and runs tests against it.
 - [Smoke tests](https://github.com/alphagov/govwifi-smoke-tests), a collection of rspec with Capybara tests, using Firefox to access the live application. These smoke test the primary service journeys (authentication, sign-up, and admin site user journeys).
+
+Google Analytics:
+
+- Google Analytics is enabled for the [admin site](https://github.com/alphagov/govwifi-admin), [product page](https://github.com/alphagov/govwifi-product-page), [Technical documentation](https://github.com/alphagov/govwifi-tech-docs) using the Google-provided javascript
+- It is enabled for the [status page](https://status.wifi.service.gov.uk/) which hosted by Atlassian, using the Atlassian management console.
+- Access to the Google Analytics platform is provided on a case-by-case basis as it incurs a cost, and is generally only accessible by the team's business analyst.
+- Any member of the team can view data collected by Google Analytics using [Google Datastudio](https://datastudio.google.com/u/0/reporting/d2311db4-fa9f-407e-ad8b-57bbd9496510/page/K2nbC)


### PR DESCRIPTION
### What
Add reference to Google Analytics/Datastudio

### Why
To inform the team from which applications data is collected and how to view it.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-340