### PR TITLE
Update GDS Ruby docker image

### DIFF
--- a/ci/pipelines/build-and-deploy.yml
+++ b/ci/pipelines/build-and-deploy.yml
@@ -68,7 +68,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: govsvc/aws-ruby
+              repository: governmentdigitalservice/aws-ruby
               tag: 2.6.1
               username: ((docker_hub_username))
               password: ((docker_hub_authtoken))
@@ -109,7 +109,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: govsvc/aws-ruby
+              repository: governmentdigitalservice/aws-ruby
               tag: 2.6.1
               username: ((docker_hub_username))
               password: ((docker_hub_authtoken))


### PR DESCRIPTION
### What
Update GDS Ruby docker image

### Why
We have been advised to do this by GDS as the old govsvc is being deprecated.

