### PR TITLE
Fix YAML parse errors caused by upgrade to Ruby 3.1.2

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,13 @@
 require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
+
+helpers do
+  def format_date(date)
+    if date.is_a?(Date)
+      date.strftime("%-e %B %Y")
+    else
+      Date.parse(date).strftime("%-e %B %Y")
+    end
+  end
+end

--- a/source/about-govwifi/device-wifi.html.md.erb
+++ b/source/about-govwifi/device-wifi.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: About the Device Wifi Alpha
 weight: 11
-last_reviewed_on: 2022-01-13
+last_reviewed_on: "2022-01-13"
 review_in: 12 months
 ---
 

--- a/source/about-govwifi/index.html.md.erb
+++ b/source/about-govwifi/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: About GovWifi
 weight: 2
-last_reviewed_on: 2022-01-13
+last_reviewed_on: "2022-01-13"
 review_in: 12 months
 ---
 

--- a/source/about-govwifi/users.html.md.erb
+++ b/source/about-govwifi/users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: About GovWifi Users
 weight: 10
-last_reviewed_on: 2022-01-13
+last_reviewed_on: "2022-01-13"
 review_in: 12 months
 ---
 

--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for GovWifi Team Manual
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 hide_in_navigation: true
 ---

--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploying applications
 weight: 20
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 
@@ -61,7 +61,7 @@ We recommend restarting the cluster using the `safe-restarter` scheduled task wh
 
 ## Docs and the product page
 
-The [Dev Docs][dev-docs-repo], [Tech Docs][tech-docs-repo], and [Product Page][product-page-repo] 
+The [Dev Docs][dev-docs-repo], [Tech Docs][tech-docs-repo], and [Product Page][product-page-repo]
 use a static site generator called [Middleman][middleman].
 
 ### Pull Request Previews

--- a/source/applications/developing.html.md.erb
+++ b/source/applications/developing.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Developing applications
 weight: 10
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/applications/index.html.md.erb
+++ b/source/applications/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Applications
 weight: 5
-last_reviewed_on: 2022-01-13
+last_reviewed_on: "2022-01-13"
 review_in: 6 months
 ---
 

--- a/source/applications/monitoring-and-instrumentation.html.md.erb
+++ b/source/applications/monitoring-and-instrumentation.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Monitoring and instrumentation
 weight: 20
-last_reviewed_on: 2022-07-18
+last_reviewed_on: "2022-07-18"
 review_in: 6 months
 ---
 

--- a/source/features/admin-2fa.html.md.erb
+++ b/source/features/admin-2fa.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Team Manual
 weight: 1
-last_reviewed_on: 2022-07-21
+last_reviewed_on: "2022-07-21"
 review_in: 6 months
 ---
 

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get started on the team
 weight: 4
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/get-started/leavers.html.md.erb
+++ b/source/get-started/leavers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Leaving
 weight: 10
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/incidents-and-alerts/bcp_and_dr.html.md.erb
+++ b/source/incidents-and-alerts/bcp_and_dr.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Business Continuity and Disaster Recovery management
 weight: 30
-last_reviewed_on: 2022-10-25
+last_reviewed_on: "2022-10-25"
 review_in: 6 months
 ---
 
 # Business Continuity and Disaster Recovery management
 
-This section outlines Business Continuity Plans (BCP) and Disaster Recovery (DR) agreements and documentation available for GovWifi service. BCP and DR documentation is stored within [team drive](https://drive.google.com/drive/folders/1QyB1M-5bwh392_7IKcsMmKuYSGxm5KPG) and is created to supports existing P1 procedures and comms. 
+This section outlines Business Continuity Plans (BCP) and Disaster Recovery (DR) agreements and documentation available for GovWifi service. BCP and DR documentation is stored within [team drive](https://drive.google.com/drive/folders/1QyB1M-5bwh392_7IKcsMmKuYSGxm5KPG) and is created to supports existing P1 procedures and comms.
 
 ## Strategy for dealing with outages
 

--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Incident management
 weight: 8
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 
@@ -144,7 +144,7 @@ We do not contact individual GovWifi users. This is because we would need the te
 
 The incident lead needs to:
 
-- send quick reports of any significant events to the portfolio-incidents email address  
+- send quick reports of any significant events to the portfolio-incidents email address
 - if there’s been a data breach, tell the Data Protection Officer and Cabinet Office, following the process documented in the service team GDPR documentation
 - talk to the team and decide what other communications are necessary
 
@@ -172,7 +172,7 @@ In GovWifi admin, locate the admin users listed for the organisation in question
 
 ### Introduce everyone involved in the incident
 
-When speaking to the organisation's incident team, make sure everyone has been properly introduced. The team may have a very different structure to ours and we need to understand their roles and hierarchy. 
+When speaking to the organisation's incident team, make sure everyone has been properly introduced. The team may have a very different structure to ours and we need to understand their roles and hierarchy.
 
 ### Align the goals of any incident calls/meetings
 

--- a/source/incidents-and-alerts/pagerduty.html.md.erb
+++ b/source/incidents-and-alerts/pagerduty.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: PagerDuty
 weight: 10
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 4 months
 ---
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Team Manual
 weight: 1
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 
@@ -26,8 +26,8 @@ If you’re not sure, check with the product manager, delivery manager or tech l
 
 ## Keeping the manual up to date
 
-Anyone on the team can update the manual. It's a shared resource and does not need a gatekeeper. 
+Anyone on the team can update the manual. It's a shared resource and does not need a gatekeeper.
 
 To update it, you need a GitHub account and to be part of the GovWifi GitHub team. You can then make changes from the [repo](https://github.com/alphagov/govwifi-dev-docs). There are [instructions on how to do this](https://docs.google.com/presentation/d/1rYhl2LdnVAoL-_-6g72U7mJwHTfO0BujHts7pnFkr7s/edit#slide=id.gbaccf4e5c5_0_11) if you're new to GitHub.
 
-To make sure we do not forget about updating the manual, each page has a review date. When a page passes that review date, there will be a prompt to review it on the `#govwifi` Slack channel. 
+To make sure we do not forget about updating the manual, each page has a review date. When a page passes that review date, there will be a prompt to review it on the `#govwifi` Slack channel.

--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: 2022-10-25
+last_reviewed_on: "2022-10-25"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/access-bastion-servers.html.md.erb
+++ b/source/infrastructure/access-bastion-servers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access bastion servers
 weight: 30
-last_reviewed_on: 2022-04-01
+last_reviewed_on: "2022-04-01"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/access-database.html.md.erb
+++ b/source/infrastructure/access-database.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access databases
 weight: 40
-last_reviewed_on: 2022-04-01
+last_reviewed_on: "2022-04-01"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/access-ecs-tasks.html.md.erb
+++ b/source/infrastructure/access-ecs-tasks.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access ECS tasks
 weight: 30
-last_reviewed_on: 2022-08-30
+last_reviewed_on: "2022-08-30"
 review_in: 3 months
 ---
 

--- a/source/infrastructure/access-gcp-components.html.md.erb
+++ b/source/infrastructure/access-gcp-components.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Access Google Cloud Platfrom (GCP) components
 weight: 90
-last_reviewed_on: 2022-05-12
+last_reviewed_on: "2022-05-12"
 review_in: 6 months
 ---
 
@@ -15,4 +15,4 @@ GCP is used in the context of:
 - access to Gmail functionality on the application level, used by smoke tests
 - access to Google Drive resources, used to store backups of Organisation Emails
 
-For details of GCP projects attributed to the GovWifi service (at various development stages), current owners and how to access and find configured resources please refer to the [GCP Projects review](https://docs.google.com/spreadsheets/d/1B0uo92ZXqCEJqZzgdQY1ncq9nohKDTS-7SJwueMgieM/) document. 
+For details of GCP projects attributed to the GovWifi service (at various development stages), current owners and how to access and find configured resources please refer to the [GCP Projects review](https://docs.google.com/spreadsheets/d/1B0uo92ZXqCEJqZzgdQY1ncq9nohKDTS-7SJwueMgieM/) document.

--- a/source/infrastructure/add-new-aws-users.html.md.erb
+++ b/source/infrastructure/add-new-aws-users.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Add new AWS users
 weight: 10
-last_reviewed_on: 2022-07-13
+last_reviewed_on: "2022-07-13"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/certificate-rotation.html.md.erb
+++ b/source/infrastructure/certificate-rotation.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi Certificates
 weight: 90
-last_reviewed_on: 2022-07-13
+last_reviewed_on: "2022-07-13"
 review_in: 6 months
 ---
 
@@ -9,18 +9,18 @@ review_in: 6 months
 
 We rotate the GovWifi certificate every year.
 
-The actual rotation is handled by the SREs. 
+The actual rotation is handled by the SREs.
 
 When the rotation is done, we need to update the following things.
 
 ## Update the product pages
 
-The [product pages](https://www.wifi.service.gov.uk/) mention the certificate GovWifi uses in text and screenshots. 
+The [product pages](https://www.wifi.service.gov.uk/) mention the certificate GovWifi uses in text and screenshots.
 
 You can find and update this content in the [product pages repo](https://github.com/alphagov/govwifi-product-page) on Github.
 
 ## Update the email template
 
-When new end users sign up, they receive an email. The email includes certificate details like the issuer and thumbprint. 
+When new end users sign up, they receive an email. The email includes certificate details like the issuer and thumbprint.
 
 You can find and update the template in [Notify](https://www.notifications.service.gov.uk/sign-in).

--- a/source/infrastructure/cloudwatch-logs.html.md.erb
+++ b/source/infrastructure/cloudwatch-logs.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: View CloudWatch logs
 weight: 20
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/continuous-delivery.html.md.erb
+++ b/source/infrastructure/continuous-delivery.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Continuous Delivery
 weight: 70
-last_reviewed_on: 2022-04-29
+last_reviewed_on: "2022-04-29"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/database-backups.html.md.erb
+++ b/source/infrastructure/database-backups.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Database backups
 weight: 50
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/database-restore.html.md.erb
+++ b/source/infrastructure/database-restore.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Database restore
 weight: 50
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/deploy-freeradius-changes.html.md.erb
+++ b/source/infrastructure/deploy-freeradius-changes.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy FreeRADIUS changes
 weight: 60
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/deploy-terraform.html.md.erb
+++ b/source/infrastructure/deploy-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy Terraform
 weight: 60
-last_reviewed_on: 2022-03-25
+last_reviewed_on: "2022-03-25"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
+++ b/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Common FreeRADIUS Errors in Cloudwatch
 weight: 80
-last_reviewed_on: 2022-08-18
+last_reviewed_on: "2022-08-18"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Debug FreeRADIUS
 weight: 100
-last_reviewed_on: 2022-08-04
+last_reviewed_on: "2022-08-04"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/free-radius/index.html.md.erb
+++ b/source/infrastructure/free-radius/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi's FreeRADIUS Implementation
 weight: 80
-last_reviewed_on: 2022-08-19
+last_reviewed_on: "2022-08-19"
 review_in: 6 months
 ---
 
@@ -23,7 +23,7 @@ User details are checked against the GovWifi users database via the FreeRADIUS R
 
 ## Authorisation
 
-GovWifi authenticates users seeking to access WiFi networks operated by host organisations which have adopted the GovWifi service. It is not used to authorise users' access to particular network services (though FreeRADIUS can be used for this). 
+GovWifi authenticates users seeking to access WiFi networks operated by host organisations which have adopted the GovWifi service. It is not used to authorise users' access to particular network services (though FreeRADIUS can be used for this).
 
 >The processing sections concerned with authorisation (distinct from the 'authorize' processing section, see above) are configured to carry out no operations in the GovWifi FreeRADIUS configuration.
 

--- a/source/infrastructure/free-radius/learn-about-freeradius.html.md.erb
+++ b/source/infrastructure/free-radius/learn-about-freeradius.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Learn about FreeRADIUS
 weight: 80
-last_reviewed_on: 2022-08-19
+last_reviewed_on: "2022-08-19"
 review_in: 3 months
 ---
 
@@ -25,7 +25,7 @@ RADIUS was introduced in 1991 to allow internet service providers to authenticat
 
 FreeRADIUS does not communicate directly with end-user devices. Devices seeking network access do so via a *Network Access Server* (NAS) which in turn sends a combination of data provided by the end-user device (e.g. credentials or a certificate) and data held by the NAS itself (e.g. its MAC address, a shared secret). In the case of GovWifi the 'NAS' is always a WiFi access point.
 
-FreeRADIUS is a highly mature, sophisticated piece of software but what it does in principle is simple. It *processes messages* in line with *policies*. 
+FreeRADIUS is a highly mature, sophisticated piece of software but what it does in principle is simple. It *processes messages* in line with *policies*.
 
 For example, a mobile phone seeks to access GovWifi via an access point. The access point transmits an 'Access-Request' message, the format of which is determined by the RADIUS specification. FreeRADIUS passess the message data through a set of stages, called 'sections'. In each section, it carries out one of more actions - determined by 'policies' - which may change the data. Simultaneously, it begins building up data to include in a response message.
 
@@ -113,7 +113,7 @@ The main configuration file is `radiusd.conf`, in the root of the configuration 
 
 >The configuration directory is `/etc/raddb` for all Linux distributions with the exception of Debian and its derivatives, where it is `/etc/freeradius/`.
 
-The entire configuration can be put in this file and that was the way FreeRADIUS 1 was designed to work. Since version 2, the configuration is by default split across separate files for virtual servers, modules and important configuration elements such as allowed IP addresses (`clients.conf`). All of these are imported into the main configuration file with an `$INCLUDE` directive. 
+The entire configuration can be put in this file and that was the way FreeRADIUS 1 was designed to work. Since version 2, the configuration is by default split across separate files for virtual servers, modules and important configuration elements such as allowed IP addresses (`clients.conf`). All of these are imported into the main configuration file with an `$INCLUDE` directive.
 
 Individual config files or whole directories of config files can be imported with `$INCLUDE`. In either case, using `$INCLUDE` is equivalent to copying and pasting the contents of the included file(s) at the point where it is used.
 
@@ -121,9 +121,9 @@ The FreeRADIUS config directory contains the following sub-directories:
 
 - **certs**: contains any certificates used as part of TLS/EAP based authentication
 - **mods-available**: contains the main configuration files for all installed modules. Much of the FreeRADIUS documentation refers to these files as 'modules' themselves though in reality they specify the work each module will undertake
-- **mods-config**: additional configuration files for modules. Not all modules needs or have them. 
+- **mods-config**: additional configuration files for modules. Not all modules needs or have them.
 >The directory structure within `mods-config` reflects the namespacing used within FreeRADIUS's main config, e.g. `mods-config/files/authorize` includes configuration for the 'files' module which is used in that module's 'authorize' block.
-- **mods-enabled**: contains symlinks to files in `mods-available`. The existence of a symlink is what enables the module. Around 30 of the modules in `mods-available` have symlinks in `mods-enabled` by default (and are therefore enabled by default). The entire contents of the directory are imported into the main config with an `$INCLUDE` directive. 
+- **mods-enabled**: contains symlinks to files in `mods-available`. The existence of a symlink is what enables the module. Around 30 of the modules in `mods-available` have symlinks in `mods-enabled` by default (and are therefore enabled by default). The entire contents of the directory are imported into the main config with an `$INCLUDE` directive.
 >Instead of creating a symlink to a module you want enabled, you can replace the symlink of the relevant module with a fresh configuration file. This is useful when trying things out because it avoids replacing the default files in 'mods-available'. These contain useful documentation but can be a headache to edit because of the sheer number of comments.
 - **policy.d**: contains policies, described using Unlang, which determine how the server processes messages. For example, `policy.d/debug` determines what information to print to the terminal when the server is run in debug mode.
 >It's important to note that the `policy.d` directory is not the only place containing policies. Policies are anything written in Unlang, throughout the configuration files, which describes how data should be processed as it flows through the processing sections.

--- a/source/infrastructure/free-radius/test-capacity.html.md.erb
+++ b/source/infrastructure/free-radius/test-capacity.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Test capacity
 weight: 100
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi infrastructure
 weight: 7
-last_reviewed_on: 2022-10-25
+last_reviewed_on: "2022-10-25"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Renew the Jenkins GPG Key
 weight: 100
-last_reviewed_on: 2022-08-04
+last_reviewed_on: "2022-08-04"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/monitoring.html.md.erb
+++ b/source/infrastructure/monitoring.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Monitoring
 weight: 20
-last_reviewed_on: 2022-08-10
+last_reviewed_on: "2022-08-10"
 review_in: 3 months
 ---
 

--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get started using Secrets
 weight: 70
-last_reviewed_on: 2022-04-13
+last_reviewed_on: "2022-04-13"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/set-up-terraform.html.md.erb
+++ b/source/infrastructure/set-up-terraform.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Set up Terraform
 weight: 60
-last_reviewed_on: 2022-08-13
+last_reviewed_on: "2022-08-13"
 review_in: 6 months
 ---
 

--- a/source/style-guide.html.md.erb
+++ b/source/style-guide.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Style guide
 weight: 20
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 12 months
 ---
 

--- a/source/update-govwifi-content.html.md.erb
+++ b/source/update-govwifi-content.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: How to update GovWifi content
 weight: 10
-last_reviewed_on: 2022-06-15
+last_reviewed_on: "2022-06-15"
 review_in: 12 months
 ---
 

--- a/source/ways-of-working/index.html.md.erb
+++ b/source/ways-of-working/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Ways of working
 weight: 3
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 3 months
 ---
 

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Zendesk
 weight: 9
-last_reviewed_on: 2022-09-07
+last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 
@@ -64,7 +64,7 @@ If individual users are having problems that are not related to their username a
 - connectivity dropping or slow internet speeds
 - not being able to access certain websites or do specific things on the network
 
-Users with these issues should contact IT support for the building they’re in. The IT team will be able to look for problems with the device or local network.  
+Users with these issues should contact IT support for the building they’re in. The IT team will be able to look for problems with the device or local network.
 
 This is because GovWifi is not a network itself. It's an authentication layer that sits on top of an organisation’s existing wifi infrastructure. It just appears as a network to end users so they know they can use their username and password to get on the internet. The network is managed by the building’s IT team, who also set the policies for network use.
 
@@ -103,9 +103,9 @@ The user will still be able to access the internet using GovWifi in other buildi
 
 Use the macro 'GovWifi - admin user - reset 2FA'. It explains that if an admin user needs to reset their 2FA:
 
-1. The admin user can ask a team member to do it for them. 
-1. The team member needs to sign into their GovWifi admin account, go to the ‘Team members’ section’ and select ‘Reset 2FA’ next to the user’s name. 
-1. The admin user can then follow the link in the email they receive, and follow the instructions to set up 2FA again. 
+1. The admin user can ask a team member to do it for them.
+1. The team member needs to sign into their GovWifi admin account, go to the ‘Team members’ section’ and select ‘Reset 2FA’ next to the user’s name.
+1. The admin user can then follow the link in the email they receive, and follow the instructions to set up 2FA again.
 
 The macro also explains that if this does not work, or if the admin does not have a team member who can do this for them, we have a [manual process](https://docs.google.com/document/d/1WDG-owrxYe58GDSjkxco1u7E-EG5_t7HLCaHT2udIvw/edit#heading=h.dr97twgaw0tc). This involves us setting up a video call with the admin and asking to see some ID. This is to be sure it's really them trying to access GovWifi admin. The process document includes more information about how do to this check.
 


### PR DESCRIPTION
### What
Fix YAML parse errors caused by upgrade to Ruby 3.1.2

### Why

To overcome errors thrown by the latest version of the YAML parser it has been necessary to overload a method in the GovUK Tech Docs template/gem.

The team responsible have been contacted in order to see whether we can get this changes in the gem. If so, we will be able to revert this element of the commit but will have to retain the other part, the quoted dates.
