### PR TITLE
Update instructions for logging into GovWifi status page

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -134,7 +134,7 @@ The type of incident will affect who the ‘relevant people’ are and how often
 The incident lead needs to:
 
 - send regular updates to the organisations that offer GovWifi in their buildings - use the latest copy of [organisation email addresses](https://drive.google.com/drive/folders/1JdeHH8q98-gVA0Flq7HwA3oDKIo-sVom) or download the list from GovWifi admin
-- open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates
+- open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates. You can do this by logging in with your work email account [here] (https://manage.statuspage.io/login). "Choose Login With Google" 
 - send quick reports of any significant events to the portfolio-incidents email address
 - if there’s been a data breach, tell the Data Protection Officer and Cabinet Office, following the process documented in the service team GDPR documentation
 


### PR DESCRIPTION
### What
Update instructions for logging into GovWifi status page.

### Why
The whole team should know how to log in to the status page.


