### PR TITLE
Suggest status page update for P2 and P3 incidents

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -5,7 +5,7 @@ last_reviewed_on: "2022-09-07"
 review_in: 6 months
 ---
 
-# Respond to alerts and incidents
+# Responding to alerts and incidents
 
 This section is a quick reference version of the [full incident management document](https://docs.google.com/document/d/1Z-F7RZ8Ogpr0U7VViRQhr5PSz0_PClGfRmN9zFvdRWo/edit#heading=h.5kgmwm1e0seq).
 
@@ -92,8 +92,6 @@ We must:
 - respond within 1 hour during business hours
 - give an update every 2 hours
 
-We should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/)
-
 ### P3 incidents (significant)
 
 These are situations where there’s intermittent or degraded service due to a platform issue.
@@ -109,8 +107,6 @@ We must:
 
 - respond within 2 hours during business hours
 - give updates every business day
-
-We should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/)
 
 ### P4 incidents (minor)
 
@@ -149,12 +145,15 @@ We do not contact individual GovWifi users. This is because we would need the te
 The incident lead needs to:
 
 - send quick reports of any significant events to the portfolio-incidents email address
+- open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates
 - if there’s been a data breach, tell the Data Protection Officer and Cabinet Office, following the process documented in the service team GDPR documentation
 - talk to the team and decide what other communications are necessary
 
 ### P3 and P4 incidents
 
 The incident lead should talk to the team and decide what communications are necessary.
+
+The team should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/). 
 
 ## Create an incident report
 

--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -92,6 +92,8 @@ We must:
 - respond within 1 hour during business hours
 - give an update every 2 hours
 
+We should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/)
+
 ### P3 incidents (significant)
 
 These are situations where there’s intermittent or degraded service due to a platform issue.
@@ -107,6 +109,8 @@ We must:
 
 - respond within 2 hours during business hours
 - give updates every business day
+
+We should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/)
 
 ### P4 incidents (minor)
 


### PR DESCRIPTION
### What
Updated P2 and P3 action sections to remind the team to consider if an incident should be opened on the status page and the link to that page.

### Why
P2 and P3 incidents have an impact on end users and admins. 

Link to Trello card (if applicable): 
n/a