### PR TITLE
Document Github onboarding powers

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -72,6 +72,8 @@ Depending on your role, you may also need access to:
 
 If you need to use Github, ask the tech lead to add you to the `alphagov` organisation and the `GovWifi` team. The main GovWifi repositories are listed on the [Learn about the GovWifi applications](/applications/#learn-about-the-govwifi-applications) page. There are further instructions on each repository.
 
+The Tech Lead has the Github privileges to add new team members to the `alphagov` organisation and relevant GovWifi Github teams. If the Tech Lead changes, these privileges must be transferred to the new Tech Lead. It's important to email the `gds-github-owners` Google group notifying them that a new Github organisation admin has been added and also add the new Tech Lead to the Google group.
+
 ## Things developers need access to
 
 As well as the things that everyone needs to do, there are extra things that new developers need.


### PR DESCRIPTION
### What

* Document who can add new team members to the alphagov org and GovWifi teams
* Indicate how to get access to admin privileges

### Why

Recently the team tried to onboard a new developer and it was unclear who had the admin privileges to add them to the alphagov organisation and relevant Github teams. After some team and organisation discussion it was decided that these privileges would reside with the Tech Lead and would be transferred to any new Tech Lead.

We wanted to codify this decision in documentation so it would be clearer next time.