### PR TITLE
Add an item to our incident summary to update the status page

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -119,9 +119,14 @@ We must:
 - respond within 1 day during business hours
 - give updates every 2 business days
 
+## Update the Status Page
+
+Add an entry briefly describing the service/s affected and level of impact.
+
 ## Work to fix the issue
 
 The tech lead should lead the actions to fix the service. All developers - frontend and infrastructure - will help.
+
 
 ## Tell the relevant people
 


### PR DESCRIPTION
### What
Add a reminder to update the status page once an incident is agreed.

### Why
We need to be ahead of the game and informing users before they inform us.

### Link to Requirement
 Please see this **[doc](https://docs.google.com/document/d/1WVKKpOOsEFQQz9Um6LsY3Qhv0TqEoszRciYbpLPAl4s/edit#heading=h.jad6x4v74mcv)**

