### PR TITLE
Remove legacy references to Concourse

### DIFF
--- a/source/about-govwifi/device-wifi.html.md.erb
+++ b/source/about-govwifi/device-wifi.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: About the Device Wifi Alpha
 weight: 11
-last_reviewed_on: "2023-03-03"
+last_reviewed_on: "2023-04-24"
 review_in: 12 months
 ---
 
@@ -67,9 +67,9 @@ To edit this file, do this:
 
 `PASSWORD_STORE_DIR=<password_store_dir> pass edit passwords/certs/production/ca.pem`
 
-Once a change has been made to this file and it has been merged into the main branch, the Concourse pipeline `sync-frontend-certs` gets triggered, which syncs the certificates to an S3 bucket which is read by the FreeRADIUS servers during initialisation.
+Once a change has been made to this file and it has been merged into the main branch, the AWS project `govwifi-codebuild-sync-certs` gets triggered, which syncs the certificates to an S3 bucket which is read by the FreeRADIUS servers during initialisation.
 
-This is only synced to staging automatically. Syncing to production must be triggered manually from Concourse, in order for any changes to take effect for production users.
+This is only synced to staging automatically. Syncing to production must be triggered manually in GovWifi AWS Production account, Codebuild, in order for any changes to take effect for production users.
 
 ## Common issues with device wifi
 

--- a/source/applications/deploying.html.md.erb
+++ b/source/applications/deploying.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploying applications
 weight: 20
-last_reviewed_on: "2023-01-20"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
@@ -12,7 +12,7 @@ help explain how we do it.
 
 ## AWS Codepipeline
 
-Deploying GovWifi is done via AWS Codepipeline and Codebuild. The code for this is found in the govwifi-deploy module of the [govwifi-terraform repo](https://github.com/alphagov/govwifi-terraform).
+Deploying GovWifi is achieved via AWS Codepipeline and Codebuild. The code for this is found in the govwifi-deploy module of the [govwifi-terraform repo](https://github.com/alphagov/govwifi-terraform).
 
 ## Core services
 
@@ -46,13 +46,10 @@ Each repo has it's own pipeline which deploys out to [GovPaaS][govpaas] whenever
 #### Trigger a deployment
 
 1. Merge your development branch to `master`.
-2. Concourse will build + deploy to GovPaaS.
+2. Github Actions will build + deploy to GovPaaS.
 3. Verify contents is deployed (you may need to add a `GET` parameter to bust the cache).
 
 
-[govwifi_concourse]: https://govwifi-cd.wifi.service.gov.uk/
-[concourse_deploy_pipeline]: https://govwifi-cd.wifi.service.gov.uk/teams/govwifi/pipelines/deploy
-[concourse_deploy_pipeline_repo]: https://github.com/alphagov/govwifi-concourse-deploy-pipeline
 [dev-docs-repo]: https://github.com/alphagov/govwifi-dev-docs
 [tech-docs-repo]: https://github.com/alphagov/govwifi-tech-docs
 [product-page-repo]: https://github.com/alphagov/govwifi-product-page

--- a/source/applications/developing.html.md.erb
+++ b/source/applications/developing.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Developing applications
 weight: 10
-last_reviewed_on: "2023-01-25"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
@@ -49,4 +49,4 @@ Once approved and merged your PR is automatically built and deployed to our stag
 
 Our pipelines include a step to force an update to the ECS tasks which are configured to use the latest image pushed to ECR.
 
-The update ECS tasks command is a function declared in the [`aws_helpers.sh` script](https://github.com/alphagov/govwifi-concourse-deploy-pipeline/blob/699cd3c989e4affbd7e0c5e5aea454e4bce85a38/aws-helpers.sh#L101), part of the `govwifi-concourse-deploy-pipeline` repo. This function is called by the `deploy.sh` script which is found in many of our repos (see [`govwifi-admin`](https://github.com/alphagov/govwifi-admin/blob/master/ci/tasks/scripts/deploy.sh) as an example).
+The update ECS projects, exist in GovWifi AWS Production account, Codebuild. These are triggered by the GovWifi AWS Tools account, Codepipeline & Codebuild projects.

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Get started on the team
 weight: 4
-last_reviewed_on: "2022-09-07"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
@@ -94,6 +94,6 @@ You need to [get access to shared secrets](/infrastructure/secrets.html).
 
 You need access to:
 
-- [Concourse](https://govwifi-cd.wifi.service.gov.uk/)
+- AWS Accounts (Production, Staging, Development & Tools)
 - [Sentry SaaS](https://sentry.io/organizations/government-digital-services/projects/)
 - Alerts and logs in [Cloudwatch](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#)

--- a/source/infrastructure/continuous-delivery.html.md.erb
+++ b/source/infrastructure/continuous-delivery.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Continuous Delivery
 weight: 70
-last_reviewed_on: "2022-11-25"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
 # Continuous Delivery
 
-GovWifi uses [AWS CodeBuild](https://aws.amazon.com/codebuild/) for its continuous delivery.
+GovWifi uses [AWS CodeBuild](https://aws.amazon.com/codebuild/) and [AWS CodePipeline](https://aws.amazon.com/codepipeline/) for its continuous delivery.
 
 ## GovWifi CI/CD history
 
@@ -18,15 +18,17 @@ The team migrated to a single-tenanted Concourse, known as GovWifi Concourse, ma
 on the [`big-little-concourse`](https://github.com/alphagov/big-little-concourse-deployment) repo developed by the
 Platform as a Service (PaaS) team.
 
-Over the course of 2022 the team migrated to AWS CodeBuild to align with Cabinet Office Digital tooling.
+Over the course of 2022 the team migrated to AWS CodePipeline & CodeBuild to align with Cabinet Office Digital tooling.
 
-## GovWifi CodeBuild
+Currently, GovWifi CI / CD exists in Github Actions for Docs repositories and AWS CodePipeline & CodeBuild for AWS hosted services.
 
-GovWifi CodeBuild is configured in the following repository:
+## GovWifi CodePipeline & CodeBuild
+
+GovWifi CodePipeline and CodeBuild tasks are configured in the following repository:
 
 - [`govwifi-terraform`](https://github.com/alphagov/govwifi-terraform) under [`govwifi-deploy`](https://github.com/alphagov/govwifi-terraform/tree/master/govwifi-deploy)
 
-Updates to the CodeBuild infrastructure configuration happen in Terraform code. Please follow the `govwifi-terraform` [README guidelines](https://github.com/alphagov/govwifi-terraform#govwifi-terraform) for contributing, updating, and deploying code changes.
+Updates to the CI/CD infrastructure configuration happen in Terraform code. Please follow the `govwifi-terraform` [README guidelines](https://github.com/alphagov/govwifi-terraform#govwifi-terraform) for contributing, updating, and deploying code changes.
 
 Pipeline configuration exists in `buildspec.yml` files in individual repos ([here is an example](https://github.com/alphagov/govwifi-admin/blob/master/buildspec.yml) for `govwifi-admin`)
 
@@ -51,7 +53,7 @@ $ gds aws govwifi-tools -l
 
 ### Monitor deployments
 
-GovWifi CodeBuild uses built-in AWS monitoring for general observability of its infrastructure.
+GovWifi CodePipeline & CodeBuild use built-in AWS monitoring for general observability of its infrastructure.
 
 You must be on the VPN and have access to the AWS console to access the monitoring.
 

--- a/source/infrastructure/index.html.md.erb
+++ b/source/infrastructure/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GovWifi infrastructure
 weight: 7
-last_reviewed_on: "2022-10-25"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
@@ -35,7 +35,7 @@ That is to say:
 
 ## Databases
 
-There are 12 databases in total:
+Currently there are 16 databases in total:
 
 ### Production
 
@@ -48,10 +48,6 @@ There are 12 databases in total:
   - Primary in London
   - Replica in London
   - Replica in Dublin
-- Concourse, PostgreSQL 13.7
-  - Primary in London
-- Concourse Grafana, PostgreSQL 10.21
-  - Primary in London
 
 ### Staging
 
@@ -62,6 +58,20 @@ There are 12 databases in total:
 - Users, MySQL 8.0
   - Primary in London
   - Replica in Dublin
+
+### Development
+
+- Admin, MySQL 5.7
+  - Primary in London
+- Sessions, MySQL 5.7
+  - Primary in London
+  - Replica in London
+- Users, MySQL 8.0
+  - Primary in London
+  - Replica in London
+  - Replica in Dublin
+
+
 
 [getting-a-secret]: /secrets.html#Getting-a-secret
 [gds-cli]: https://github.com/alphagov/gds-cli

--- a/source/infrastructure/jenkins-key-expired.html.md.erb
+++ b/source/infrastructure/jenkins-key-expired.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Renew the Jenkins GPG Key
 weight: 100
-last_reviewed_on: "2023-03-03"
+last_reviewed_on: "2023-04-24"
 review_in: 6 months
 ---
 
@@ -11,6 +11,6 @@ review_in: 6 months
 
 If you see an error stating that this key has expired, please contact the GovWifi SREs.
 
-You may encounter this error when trying to re-encrypt the secrets in [govwifi-build](https://github.com/alphagov/govwifi-build) or in output of one of our Concourse pipelines - [like the `sync-frontend-certs` pipeline](https://cd.gds-reliability.engineering/teams/govwifi/pipelines/sync-frontend-certs).
+You may encounter this error when trying to re-encrypt the secrets in [govwifi-build](https://github.com/alphagov/govwifi-build).
 
 If you are a member of the SRE team and you are looking for further documentation, please review [these instructions](https://docs.google.com/document/d/16xFh1ZSAnw5o-MN5rP8BRz0701AlJ4rWXG3jY7YNWjY/edit).


### PR DESCRIPTION
### What
We need to remove legacy references to Concourse.
We will retain a short description of our CI/CD history so that new joiners will know how we arrived here.

### Why
Concourse has been decommissioned.
We should keep our team documents up to date.

### Testing
Follow the instructions **[here](https://github.com/alphagov/govwifi-dev-docs/blob/master/README.md)** to test locally.

### Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?label=GovWifi-SRE&selectedIssue=GW-851