### PR TITLE
Add org list info to the update content page

### DIFF
--- a/source/update-govwifi-content.html.md.erb
+++ b/source/update-govwifi-content.html.md.erb
@@ -117,6 +117,10 @@ Once your texts or emails are sent, you can see how many people they were succes
 
 There are also some analytics in Notify, such as how many times each of your templates have been sent over different time periods.
 
+## Organisation lists
+
+There are several organisation lists, these are used to show which admins have setup GovWifi, which organisations allowed to sign up and a public list of organisations. There's further [guidance](https://govwifi-dev-docs.cloudapps.digital/lists-of-organisations.html) in the team manual on how these work and who can edit them.
+
 ## User support macros
 
 ### What


### PR DESCRIPTION
### What
Add a link on the 'updating content' page of the team manual to link to the new page about organisation lists.

### Why
Organisation lists may need to be frequently updated. Linking from this page to make it more likely people discover this information in the future.

Link to Trello card (if applicable):  https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-888