### PR TITLE
Add a procedure to test FreeRADIUS authentication locally.

### DIFF
--- a/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
+++ b/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Common FreeRADIUS Errors in Cloudwatch
-weight: 80
+weight: 30
 last_reviewed_on: "2023-06-15"
 review_in: 6 months
 ---

--- a/source/infrastructure/free-radius/debug.html.md.erb
+++ b/source/infrastructure/free-radius/debug.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Debug FreeRADIUS
-weight: 100
+weight: 50
 last_reviewed_on: "2023-03-03"
 review_in: 6 months
 ---

--- a/source/infrastructure/free-radius/learn-about-freeradius.html.md.erb
+++ b/source/infrastructure/free-radius/learn-about-freeradius.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Learn about FreeRADIUS
-weight: 80
+weight: 10
 last_reviewed_on: "2023-06-15"
 review_in: 6 months
 ---

--- a/source/infrastructure/free-radius/manual-freeradius-test.md.erb
+++ b/source/infrastructure/free-radius/manual-freeradius-test.md.erb
@@ -9,7 +9,7 @@ If you need to test the new FreeRADIUS ECS tasks manually (e.g. when the new Env
 
 ## Prerequsites
 
-We will be using the ECS Exec so please ensure your machine is configure in line with the Prerequsites listed [here](https://govwifi-dev-docs.cloudapps.digital/infrastructure/access-ecs-tasks.html) and you are connected to the VPN.
+We will be using the ECS Exec so please ensure your machine is configured in line with the prerequisites listed, [you can check your machines prerequisites here](https://govwifi-dev-docs.cloudapps.digital/infrastructure/access-ecs-tasks.html) and you are connected to the VPN.
 
 ## Get list of the FreeRADIUS tasks
 

--- a/source/infrastructure/free-radius/manual-freeradius-test.md.erb
+++ b/source/infrastructure/free-radius/manual-freeradius-test.md.erb
@@ -1,0 +1,82 @@
+---
+title: Test FreeRADIUS on the ECS task level
+weight: 70
+last_reviewed_on: "2023-08-01"
+review_in: 6 months
+---
+
+If you need to test the new FreeRADIUS ECS tasks manually (e.g. when the new Environmnet is created and Smoke tests are not deployed yet) you can use the steps listed below.
+
+## Prerequsites
+
+We will be using the ECS Exec so please ensure your machine is configure in line with the Prerequsites listed [here](https://govwifi-dev-docs.cloudapps.digital/infrastructure/access-ecs-tasks.html) and you are connected to the VPN.
+
+## Get list of the FreeRADIUS tasks
+
+You can check the FreeRADIUS task ID directly from the AWS Console or use following `gds-cli` command:
+
+```
+gds-cli aws <account-name> --region eu-west-2 -- aws ecs list-tasks --cluster frontend-fargate --service-name load-balanced-frontend
+```
+
+## Connect to the FreeRADIUS tasks
+
+Use the task ID obtained in the previous step and run the following command to estabilish ssh session to the task:
+
+```
+gds-cli aws <account-name> -- aws ecs execute-command --cluster frontend-fargate --task one_of_the_task_IDs_from_the_previous_step_here --container frontend-radius --interactive --command "/bin/sh"
+```
+
+## Check the healthcheck’s config file name
+
+### Command:
+```
+ls -l /tmp/healthcheckpeap-mschapv2.conf.*
+```
+
+### An example output:
+```
+-rw-------    1 root     root           393 May 11 13:41 /tmp/healthcheckpeap-mschapv2.conf.erb20230511-20-8hrusp
+```
+
+You need to make a note of the full path of listed filename as it will be used in the command in the next step (e.g. /tmp/healthcheckpeap-mschapv2.conf.erb20230511-20-8hrusp)
+
+## Run the Healthcheck test locally
+
+You need to update the command with the name of healtcheck file captured in the previous step:
+
+```
+eapol_test -c /tmp/healthcheckpeap-mschapv2.conf.erb_random_string_here -s $HEALTH_CHECK_RADIUS_KEY
+```
+
+e.g.
+
+```
+eapol_test -c /tmp/healthcheckpeap-mschapv2.conf.erb20230511-20-8hrusp -s $HEALTH_CHECK_RADIUS_KEY
+```
+
+# Desired result output
+
+```
+EAPOL: SUPP_PAE entering state AUTHENTICATED
+EAPOL: SUPP_BE entering state RECEIVE
+EAPOL: SUPP_BE entering state SUCCESS
+EAPOL: SUPP_BE entering state IDLE
+eapol_sm_cb: result=1
+EAPOL: Successfully fetched key (len=32)
+PMK from EAPOL - hexdump(len=32): 12 23 45 78 90 12 34 56 ......
+No EAP-Key-Name received from server
+WPA: Clear old PMK and PTK
+EAP: deinitialize previously used EAP method (25, PEAP) at EAP deinit
+ENGINE: engine deinit
+MPPE keys OK: 1  mismatch: 0
+SUCCESS
+```
+
+## Healthchecks credential explained
+
+`HEALTH_CHECK_IDENTITY` and `HEALTH_CHECK_PASSWORD` secrets are passed to the healtcheck from the Environmnet variables (you can check these using `export` command in the console). 
+
+`HEALTH_CHECK_RADIUS_KEY` is also passed from the Environmnet variables. It must match the secret injected to the FreeRADIUS configuration in Line 1 of following config file:
+
+`/etc/raddb/certs/clients.conf`

--- a/source/infrastructure/free-radius/test-capacity.html.md.erb
+++ b/source/infrastructure/free-radius/test-capacity.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Test capacity
-weight: 100
+weight: 90
 last_reviewed_on: "2023-06-15"
 review_in: 2 months
 ---


### PR DESCRIPTION
### What
We want to document the method how to test FreeRADIUS authentication directly from the ECS tasks.

### Why
We have used this procedure to test FreeRADIS auth locally during the creating new GovWifi environment during the BCP test. 
