### PR TITLE
docs: [GW-1043] update instructions.

### DIFF
--- a/source/infrastructure/secrets.html.md.erb
+++ b/source/infrastructure/secrets.html.md.erb
@@ -49,11 +49,10 @@ An example of a key ID is: `06D20CF70AC370DE72F49EDC992939FDD5C5144C`
 
 Please also ensure your public key is on a well known keyserver:
 
-We suggest `hkps.pool.sks-keyservers.net` and `keyserver.ubuntu.com`, as they are known to be reliable.
+We suggest `keyserver.ubuntu.com` as they are known to be reliable.
 
 ```sh
 gpg --keyserver keyserver.ubuntu.com --send-keys '<your key ID>'
-gpg --keyserver hkps.pool.sks-keyservers.net --send-keys '<your key ID>'
 ```
 
 ### Giving Access
@@ -90,7 +89,22 @@ make rencrypt-passwords
 
 Note: `make` commands can only be run from the root project directory.
 
-Once the secrets have been re-encrypted, use git to commit and push the changes in the `.private` directory.
+There can be a number of reason for this to fail, for example one of the keys could have expired, if that's the case, contact the owner of the key and ask them to extned their expiration date and reupload their key to the server.
+
+To extend key expiry 
+```
+$ gpg --list-keys
+$ gpg --edit-key KEYID`
+> expire
+> 2y
+> y
+> trust
+> 5
+> save <-- Very important!
+---
+then upload the key again.
+
+Once the secrets have been re-encrypted, use git to add, commit and push the changes in the `.private` directory.
 
 Raise a PR in the `govwifi-build` repo on Github. Ask another team member to test the encryption has worked by checking out the PR branch and testing they can decrypt the files using `gpg -d`.
 
@@ -103,6 +117,14 @@ To do this read in all the keys in `passwords/.gpg-id` and import them:
 ```
 $ gpg --keyserver keyserver.ubuntu.com --receive-keys <key_id> && gpg --import-ownertrust
 ```
+
+If you are a new starter you'll have to do this for every team members key, so to speed things up, cat out the keys and use the ouptut in the command.
+```sh
+## get all the keys
+cat .gpg-id | tr '\n' ' '
+## paste the output to.
+gpg --keyserver keyserver.ubuntu.com --receive-keys <keys> && gpg --import-ownertrust
+````
 
 ### Getting a secret
 


### PR DESCRIPTION
### What
Update the docs to remove a dead server, add a few helpful hints if thing fail, and quick way to import keys.

### Why
To make it easier to onboard new staff.

Link to Trello card (if applicable): 
[Jira issue GW-1043](https://technologyprogramme.atlassian.net/browse/GW-1043)