### PR TITLE
Update incident documentation

### DIFF
--- a/source/incidents-and-alerts/index.html.md.erb
+++ b/source/incidents-and-alerts/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Incident management
 weight: 8
-last_reviewed_on: "2023-05-30"
+last_reviewed_on: "2024-02-02"
 review_in: 6 months
 ---
 
@@ -25,10 +25,6 @@ Emails are sent to GovWifi critical alerts mailbox. Notifications are sent to th
 
 Emails are sent to the GovWifi support mailbox. Notifications are sent to the #govwifi Slack channel.
 
-### PaaS alerts
-
-Emails are sent to the GovWifi support mailbox.
-
 ### Notify alerts
 
 Emails are sent to the GovWifi support mailbox and StatusPage.
@@ -39,15 +35,15 @@ Emails are sent to the GovWifi support mailbox and StatusPage.
 2. Find out if anyone else is already investigating the issue.
 3. If the issue is security related, tell the Cyber Security Team. You can use the #cyber-security-help Slack channel.
 
-## Appoint an incident lead
+## Appoint an incident lead and a communication lead  
 
-Make sure the product manager, delivery manager or tech lead is aware of the incident.
+Make sure the product manager, delivery manager, engagement manager or tech lead is aware of the incident.
 
-One of them will be the ‘incident lead’.
+One of them will be the **communication lead**. Appoint another person to be an **incident lead**. This will usually be a developer or an SRE, or a person actively working on fixing incident.
 
 ## Categorise the incident
 
-The tech lead should lead the categorisation of the incident and discuss it with the relevant people.
+The incident lead should lead the categorisation of the incident and discuss it with the relevant people on the team.
 
 ### P1 incidents (critical)
 
@@ -125,50 +121,51 @@ Add an entry briefly describing the service/s affected and level of impact.
 
 ## Work to fix the issue
 
-The tech lead should lead the actions to fix the service. All developers - frontend and infrastructure - will help.
+The tech lead and incident lead should lead the actions to fix the service. All developers - frontend and infrastructure - will help.
 
 
 ## Tell the relevant people
 
-The incident lead should make sure that the relevant people know about the incident.
+The communications lead should make sure that the relevant people know about the incident.
 
 The type of incident will affect who the ‘relevant people’ are and how often they should be updated.
 
 ### P1 incidents
 
-The incident lead needs to:
+The communications lead needs to:
 
-- send regular updates to the organisations that offer GovWifi in their buildings - use the latest copy of [organisation email addresses](https://drive.google.com/drive/folders/1JdeHH8q98-gVA0Flq7HwA3oDKIo-sVom) or download the list from GovWifi admin
-- open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates. You can do this by logging in with your work email account [here] (https://manage.statuspage.io/login). "Choose Login With Google" 
-- send quick reports of any significant events to the portfolio-incidents email address
-- if there’s been a data breach, tell the Data Protection Officer and Cabinet Office, following the process documented in the service team GDPR documentation
+- Open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates. You can do this by [logging in to the Status page](https://manage.statuspage.io/login) with your work email account . "Choose Login With Google" 
+- If there’s been a data breach, tell the [Data Protection Officer](https://docs.google.com/document/d/15L4Uuf40dA5X4G4Q6HWRSMhS-IXVM2ku148OuuSTBEo/edit#heading=h.rm3docbhz2ia). More information about this process can be found in the [Risk Assessment Document](https://docs.google.com/document/d/1q_cunkqdzLnFJswRUMMXoo5I2kkjHqHQ/edit) (the entire document does not have to be read during the incident, the most important thing is to alert the Data Protection Officier of the breach).  
 
-We do not contact individual GovWifi users. This is because we would need the technical team to extract user information from the database. This takes time, which would be better spent fixing the service.
+We do not contact individual GovWifi users. This is because we would need the technical team to extract user information from the database. This takes time, which would be better spent fixing the service. Individual users can subscribe to the status page for regular updates.
 
 ### P2 incidents
 
-The incident lead needs to:
+The communication lead needs to:
 
-- send quick reports of any significant events to the portfolio-incidents email address
 - open an incident on the [GovWifi status page](https://status.wifi.service.gov.uk/) and add regular updates
-- if there’s been a data breach, tell the Data Protection Officer and Cabinet Office, following the process documented in the service team GDPR documentation
+- if there’s been a data breach, tell the [Data Protection Officer](https://docs.google.com/document/d/15L4Uuf40dA5X4G4Q6HWRSMhS-IXVM2ku148OuuSTBEo/edit#heading=h.rm3docbhz2ia). More information about this process can be found in the [Risk Assessment Document](https://docs.google.com/document/d/1q_cunkqdzLnFJswRUMMXoo5I2kkjHqHQ/edit) (the entire document does not have to be read during the incident, the most important thing is to alert the Data Protection Officier of the breach). 
 - talk to the team and decide what other communications are necessary
 
 ### P3 and P4 incidents
 
-The incident lead should talk to the team and decide what communications are necessary.
+The incident and communication lead should talk to the team and decide what communications are necessary.
 
 The team should decide if an incident should be opened on the [GovWifi status page](https://status.wifi.service.gov.uk/). 
 
 ## Create an incident report
 
-The incident lead needs to create an incident report using the [report template](https://docs.google.com/document/d/1WVKKpOOsEFQQz9Um6LsY3Qhv0TqEoszRciYbpLPAl4s/edit#heading=h.jad6x4v74mcv).
+The incident and communication lead needs to create an incident report using the [report template](https://docs.google.com/document/d/1WVKKpOOsEFQQz9Um6LsY3Qhv0TqEoszRciYbpLPAl4s/edit#heading=h.jad6x4v74mcv).
 
 Throughout the incident, record actions taken, decisions, significant external communications in the report. Include timestamps.
 
 ## After the incident
 
 When the incident is resolved, the incident lead needs to record the completed template with a unique ID in the [Incident Log](https://docs.google.com/spreadsheets/d/1NKk_XgXFooHSLlnKtIGMsWeKy9Ws3WU61VtcRdH2OIE/edit).
+
+The Delivery Manager should organise an incident retro with the team. Try to keep this within two weeks of the incident where possible. You do not have to have been involved in the Incident in order to attend the retro. Everyone on the GovWifi team is welcome to attend and learn. 
+
+Also ensure you add the incident to the GPA monthly reporting document.
 
 ## Helping other organisation incident management teams with their incidents
 


### PR DESCRIPTION
### What
Update incident documentation

### Why
Updated the incident documentation to reflect changes in process. The status page serves as the main update mechanism which nullifies the need to send out mass emails. Organisations and individuals that are interested in receiving updates about an incident should be asked to subscribe to the status page.

Link to Jira card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1410
