### PR TITLE
Update monitoring.html.md.erb

### DIFF
--- a/source/infrastructure/monitoring.html.md.erb
+++ b/source/infrastructure/monitoring.html.md.erb
@@ -46,9 +46,9 @@ Prior to November 2023 there was an additional Grafana which was hosted on GOV.U
 
 ## Google Analytics
 
-We currently have a tab with default Google Analytics dashboard
-open. This will be iterated over to make it more useful in the near
-future.
+We currently have a [Google Analytics](https://lookerstudio.google.com/u/0/reporting/60ddcf7e-668b-4a29-b5ab-e27007b5e27e/page/ycpjB) dashboard which shows a summary of visits to our Product Page and Admin site. 
+
+There is an [additional dashboard](https://lookerstudio.google.com/u/0/reporting/d2311db4-fa9f-407e-ad8b-57bbd9496510/page/K2nbC) which used to allow for more detailed investigations of how people used these pages. However, this dashboard is currently broken.
 
 ## Prometheus
 


### PR DESCRIPTION
### What
Add link to the Google Analytics dashboard that works
Add link to the currently broken GA dashboard

### Why
So people can see visitor numbers. So if we get a new performance analyst they don't start from zero if we wish to update the more detailed dashboard.
