### PR TITLE
Add documentation around rotating passwords safely

### DIFF
--- a/source/infrastructure/database-rotate-passwords.html.md.erb
+++ b/source/infrastructure/database-rotate-passwords.html.md.erb
@@ -1,0 +1,58 @@
+---
+title: Database password rotation
+weight: 50
+last_reviewed_on: "2024-05-31"
+review_in: 12 months
+---
+
+# How to Rotate Database Passwords
+
+This guide sets out how to perform database password rotation without causing downtime for any of the GovWifi Applications. 
+
+## Overview Of Process
+
+The password must be updated first on the RDS instance, then on the app. The apps run as ECS tasks and load the database passwords into memory as an environment variable from AWS Secret Manager when they first start. If the secret is changed, they will only pick up the new value at launch time. Existing tasks have no way to detect that the secret has changed.
+
+## Instructions
+
+Set a dual password for the RDS master user by following the instructions below
+1. Log into the bastion box
+1. Connect to the RDS database server by [following these instructions](https://dev-docs.wifi.service.gov.uk/infrastructure/access-database.html#admin-database)
+1. Once in the mysql console select your database for example
+
+```
+    use govwifi_staging;
+```
+
+Run the following command and replace "username" with the RDS master username "newpass" with the new password you wish to use.
+
+```
+ALTER USER 'username' IDENTIFIED BY 'newpassword' RETAIN CURRENT PASSWORD;
+```
+
+The above sets a dual password, without deleting the old one. This is important because the apps running as ECS tasks will still be using the old password. If you do not retain the old password the app will fail to connect to the database and cause an incident. [Ensure your new password conforms to best practice](https://dev.mysql.com/doc/refman/8.0/en/validate-password.html)
+
+## Update the database password used by the ECS task. 
+
+1. Change the database password in the Secrets Manager
+1. The naming convention for these passwords is `rds/db/credentials`. For example the name of the sessions database secret would be `rds/session-db/credentials`: 
+   1. Restart the affected applications
+   1. You will need to restart different combinations of ECS tasks depending on which database password you are changing. Stop one ECS task and check that it restarts successfully. Run the smoke tests. If all is well, stop the remaining tasks. ECS will launch new tasks with the new password automatically:
+   1. If you've changed the password for the **sessions database** you will need to restart:
+      - Logging-api tasks
+      - Admin tasks
+   1. If you've changed the password for the **admin database** you will need to restart:
+      - Admin tasks
+   1. If you've changed the password for the **user database** you will need to restart:
+      - Admin tasks
+      - Logging-api tasks
+      - User-sign-up-api tasks
+
+   
+      **Make sure you check both regions for tasks (both eu-west-2 and eu-west-1).**
+2. Delete the old password permanently by running the following command on the mysql prompt:
+
+```
+    ALTER USER 'username' DISCARD OLD PASSWORD;
+```
+


### PR DESCRIPTION
### What
Add documentation around rotating passwords safely

### Why
In order to rotate database passwords without downtime, our databases and apps needs to accept two passwords at once. An old one and a new one. Now that our databases are using mysql 8. We can take advantage of the dual password functionality to rotate our database passwords safely. The documentation has been updated to reflect this.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1675
