### PR TITLE
GW-1646 Create a build workflow to test if pages build.

### DIFF
--- a/.github/workflows/build-dev-docs.yml
+++ b/.github/workflows/build-dev-docs.yml
@@ -1,0 +1,27 @@
+name: build-on-pr
+on: [pull_request]
+jobs:
+
+    build_dev_docs:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+  
+        - name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: 'latest'
+  
+        - name: Setup ruby
+          uses: ruby/setup-ruby@v1
+          with:
+            bundler-cache: true
+  
+        - name: Install ruby dependencies
+          run: bundle install
+  
+        - name: Build static site
+          run: bundle exec middleman build
+  


### PR DESCRIPTION
### What
Add a build workflow to run when a PR is created.

### Why
To ensure Dev Pages will build before it's merged into master, this is useful in determining if a Dependabot change will impact the build process, ensuring more confidence that a dependabot update wont break the build.

### Link to JIRA card (if applicable): 
[GW-1646](https://technologyprogramme.atlassian.net/browse/GW-1646)

[GW-1646]: https://technologyprogramme.atlassian.net/browse/GW-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ