### PR TITLE
fix: [GW-1729] Update actions to latest versions.

### DIFF
--- a/.github/workflows/build-dev-docs.yml
+++ b/.github/workflows/build-dev-docs.yml
@@ -10,7 +10,7 @@ jobs:
             fetch-depth: 0
   
         - name: Setup node
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@v4
           with:
             node-version: 'latest'
   

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -31,7 +31,7 @@ jobs:
         run: bundle exec middleman build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
           
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### What
Update Github Actions to latest versions

### Why
Security, reliability and old versions being deprecated 

### Link to JIRA card (if applicable): 
[GW-1729](https://technologyprogramme.atlassian.net/browse/GW-1729)

[GW-1729]: https://technologyprogramme.atlassian.net/browse/GW-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ