### PR TITLE
docs: [GW-1865]Add SSM Docs

### DIFF
--- a/source/infrastructure/access-bastion-servers.html.md.erb
+++ b/source/infrastructure/access-bastion-servers.html.md.erb
@@ -1,25 +1,26 @@
 ---
 title: Access bastion servers
 weight: 30
-last_reviewed_on: "2024-06-15"
+last_reviewed_on: "2024-08-15"
 review_in: 6 months
 ---
 
 # Access bastion servers
+As we move from SSH to SSM, this server is now used to access the database, access to the other ec2's is made directly via SSM.
 
 ## Secrets
 
 [Extract the SSH Key secrets](https://dev-docs.wifi.service.gov.uk/infrastructure/secrets.html#get-started-using-secrets) for the bastion server:
 
-- staging secret name: `keys/govwifi-staging-temp-bastion-key-20200717`
+- Dev (alpaca) secret name: `keys/alpaca-bastion-20230120`
+- staging secret name: `keys/govwifi-staging-bastion-key-20200717`
 - production secret name: `keys/govwifi-bastion-key`
 
-Find out the Elastic IPs for the bastion servers. You can do this by logging into the AWS console,
-and finding the instances which contain the word "Bastion".
+## SSH/SSM Config
 
-## SSH Config
+We have transitioned to SSM, there should be no differences when running commands, the only difference is in the config, for example you'll now need to know the instance id of the host rather than the IP address.
 
-We recommended setting up an SSH config for ease of use. Instructions how to set up your SSH config exist in the Password Store of GovWifi where you can run:
+We recommended setting up a SSH config for ease of use. Instructions how to set up your SSH config exist in the Password Store of GovWifi where you can run:
 
 ```sh
 PASSWORD_STORE_DIR=<password_store_dir> pass show ssh/instructions.txt

--- a/source/infrastructure/set-up-aws-cli-and-ssm-plugin.html.md.erb
+++ b/source/infrastructure/set-up-aws-cli-and-ssm-plugin.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Access the AWS CLI and SSM plugin
+weight: 20
+last_reviewed_on: "2024-08-21"
+review_in: 6 months
+---
+
+# AWS CLI
+If you have not done already, you'll need to [visit the AWS CLI webpage for instructions on how to install for your operating system](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+# AWS SSM Plugin for AWS CLI.
+To access the EC2, you'll need to have the SSM Client plugin installed, [visit the SSM Client webpage for instructions on how to install for your operating system](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+
+# Start SSM session via AWS Console.
+Log into the AWS CLI on either dev, staging or prod (need to use admin account).
+Go to Systems Manager, under 'Node Management' on the left menu select 'Session Manager'
+Press the Orange 'start session' button, the next screen should show a list of instances eg
+```
+Alpaca Grafana-Server
+Alpaca Bastion - backend 
+Alpaca Prometheus-Server
+```
+Select the radio button next to the instance needed, then click the  'start session' button
+A new window with a terminal session will be shown.
+
+# Start SSM session via AWS CLI.
+Assuming the SSM plugin has been installed, you can start a standard SSM (NOT SSH) session by
+
+```
+gds aws govwifi-development -- aws ssm start-session --target <EC2 instance Id>
+````
+
+# SSH over SSM
+
+To do this, the hosts file will need to be setup, SSH keys downloaded.
+
+For instructions on how to setup the hosts file and obtain the keys, decrypt and read the instructions from the build repo.
+```sh
+PASSWORD_STORE_DIR=<path_to_password_store_dir> pass show ssh/instructions.txt
+```
+
+# SCP over SSM
+Once the hosts file has been configured and can successfully SSH into the instance, then to upload and download file via SCP do this.
+### Upload
+```
+scp ./<file-to-upload> bastion.dev.govwifi:<path-from-root>
+```
+### Download
+```
+scp bastion.dev.govwifi:<path-from-root>/<file-to-download> <path/to/store/file-to-download>
+```


### PR DESCRIPTION
### What
Added instructions for SSM

### Why
So that devs/sres can access the ec2 instances via ssm

### Link to JIRA card (if applicable): 
[GW-1865](https://technologyprogramme.atlassian.net/browse/GW-1865)


[GW-1865]: https://technologyprogramme.atlassian.net/browse/GW-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ