### PR TITLE
Add Link To Pagerduty Documentation

### DIFF
--- a/source/incidents-and-alerts/pagerduty.html.md.erb
+++ b/source/incidents-and-alerts/pagerduty.html.md.erb
@@ -1,13 +1,18 @@
 ---
 title: PagerDuty
 weight: 12
-last_reviewed_on: "2024-11-09"
+last_reviewed_on: "2025-05-06"
 review_in: 6 months
 ---
 
 # PagerDuty
 
 PagerDuty is used for out of hours alerting. PagerDuty listens to sns notifications from AWS about a subset of the CloudWatch alarms.
+
+## Configuring PagerDuty
+
+ Configuration of the on-call schedule is done in the PagerDuty web interface. For details on how to setup PagerDuty with AWS, or adjust any of the settings, please see
+ <b> </br> [PagerDuty Configuration Doc in the GovWifi Google Drive](https://docs.google.com/document/d/1KIOyNAC_15unYRH7aEECKTkcNID6o0Pa___M3VmtBpI/edit?tab=t.0#heading=h.vna0jm7rghiz). </b> 
 
 ## CloudWatch alarms
 


### PR DESCRIPTION
### What
Add Link To Pagerduty Documentation

### Why
Add link to pagerduty configuration documentation, for more details relating to the way AWS and PagerDuty connect to each other.

