### PR TITLE
Add Link To Pagerduty Documentation

### DIFF
--- a/source/incidents-and-alerts/pagerduty.html.md.erb
+++ b/source/incidents-and-alerts/pagerduty.html.md.erb
@@ -1,13 +1,18 @@
 ---
 title: PagerDuty
 weight: 12
-last_reviewed_on: "2024-11-09"
+last_reviewed_on: "2025-05-06"
 review_in: 6 months
 ---
 
 # PagerDuty
 
 PagerDuty is used for out of hours alerting. PagerDuty listens to sns notifications from AWS about a subset of the CloudWatch alarms.
+
+## Configuring PagerDuty
+
+ Configuration of the on-call schedule is done in the PagerDuty web interface. For details on how to setup PagerDuty with AWS, or adjust any of the settings, please see
+ <b> </br> [PagerDuty Configuration Doc in the GovWifi Google Drive](https://docs.google.com/document/d/1KIOyNAC_15unYRH7aEECKTkcNID6o0Pa___M3VmtBpI/edit?tab=t.0#heading=h.vna0jm7rghiz). </b> 
 
 ## CloudWatch alarms
 

--- a/source/zendesk-support/index.html.md.erb
+++ b/source/zendesk-support/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Zendesk
 weight: 9
-last_reviewed_on: "2025-04-04"
+last_reviewed_on: "2025-05-14"
 review_in: 6 months
 ---
 
@@ -127,3 +127,7 @@ If they continue to report issues, use the ["Questions for organisations facing 
 The more we know about the issue the better able we are to investigate.
 
 If the organisation is experiencing an incident, regardless of whether the root cause is GovWifi or not, we recommend following the steps outlined in ["Helping other organisation incident management teams with their incidents"](https://docs.google.com/document/d/1eO6eNtks-k3rW4KWXIMctlVHV5vqD8hN5SUM_jO4biM/).
+
+## In the logs on the Admin Portal, some Username or ID fields are blank, but show a Status of successful. Why is this?
+
+Blank username and ID fields indicate that users on your networks are authenticating via certificate based authentication (EAP-TLS), versus EAP-PEAP (username/passwords).  Users can do this even though your specific organisation doesn't have CBA enabled in the Admin Portal. This is part of the service, which allows users to roam regardless of their authentication method.


### PR DESCRIPTION
### What
Add Link To Pagerduty Documentation

### Why
Add link to pagerduty configuration documentation, for more details relating to the way AWS and PagerDuty connect to each other.

