### PR TITLE
dcos: [GW-2335] Add Auto Scaler Docs.

### DIFF
--- a/source/incidents-and-alerts/cloudwatch_alerts.html.md.erb
+++ b/source/incidents-and-alerts/cloudwatch_alerts.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: CloudWatch Alarms
 weight: 10
-last_reviewed_on: "2025-08-07"
-review_in: 6 months
+last_reviewed_on: "2025-08-08"
+review_in: 12 months
 ---
 
 # CloudWatch Alarms
@@ -24,6 +24,10 @@ These are critical alarms and are [detailed on the PagerDuty page](/incidents-an
 
 ### Radius Cannot Connect to API.
 This can occur if a Security Group has been miss configured, preventing Radius accessing the Authentication or logging API's, check CloudWatch logs. This is a filter on the Frontend cloudwatch group looking for messages containing "ERROR: Server returned no data",
+
+### EAP-too-many-open-sessions
+Radius has a limit of EAP Open sessions, this should now trigger the auto scaler to spin up new tasks, monitor as this indicates increase in traffic or a radius problem.
+If it is agreed the problem has been dealt with, the tasks will have to be manually scaled back using the CodeBuild job.
 
 ### Bastion Status Alarm.
 this alarm will trigger if the EC2 instance responsible for the bastion is not responding, check the Cloudwatch logs, EC2 Instance Health, restart the instance if'it's failed.

--- a/source/infrastructure/access-aws-console.html.md.erb
+++ b/source/infrastructure/access-aws-console.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Access the AWS console
 weight: 20
-last_reviewed_on: "2025-08-07"
-review_in: 6 months
+last_reviewed_on: "2025-08-08"
+review_in: 12 months
 ---
 
 # Access the AWS console
@@ -15,15 +15,15 @@ Staging and Production are hosted in different AWS accounts.
 
 Ask the reliability engineers for the GovWifi account IDs. AWS roles are in the form `firstname.lastname-admin` or `firstname.lastname-readonly`.
 
-#### Using gds-cli
+#### Using cod-cli
 
 This utility is being replaced with cod-cli (https://github.com/GovWifi/cod-cli).
 
 The remainder of this section is retained until everyone has migrated to cod-cli
 
-You can also use the [`gds-cli`](https://github.com/alphagov/gds-cli) to access the GovWifi AWS console.
+You can also use the [`cod-cli`](https://github.com/govwifi/cod-cli) to access the GovWifi AWS console.
 
-Review the [configuration instructions](https://github.com/alphagov/gds-cli#configuration) on the `gds-cli` README to set it up. Note: gds-cli may be aliased to gds. [Indepth guidance on setting up the gds-cli can be found on GDS's help pages](https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#installing-gds-cli).
+Review the [configuration instructions](https://github.com/govwifi/cod-cli#configuration) on the `gds-cli` README to set it up. Note: gds-cli may be aliased to gds. [Indepth guidance on setting up the gds-cli can be found on GDS's help pages](https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#installing-gds-cli).
 
 Once the `gds-cli` is set up, run the following command from anywhere in your terminal to login as `read-only` to Production:
 
@@ -67,3 +67,17 @@ You can login as `admin` to Recovery by running the following command:
 ```
 $ gds aws govwifi-recovery -l
 ```
+## Extend Session time
+By default the session time is 1 hour, then you get logged out, this can br frustrating, especially if you have several tabs open, thankfully there is a way to fix this.
+### From CLI
+`cod-cli aws govwifi-development -l --art 8h`
+### From Console.
+* Log into AWS console,
+* Switch to desired env, eg Dev, Staging, Prod.
+* Goto IAM
+* Goto Role
+* Search for your name.
+* Select your role.
+* Click Edit
+* Change Maximum session duration
+* Save

--- a/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
+++ b/source/infrastructure/free-radius/cloudwatch-errors.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Common FreeRADIUS Errors in Cloudwatch
 weight: 30
-last_reviewed_on: "2025-03-13"
+last_reviewed_on: "2025-08-07"
 review_in: 6 months
 ---
 

--- a/source/infrastructure/free-radius/ecs-task-auto-scaler.html.md.erb
+++ b/source/infrastructure/free-radius/ecs-task-auto-scaler.html.md.erb
@@ -1,0 +1,40 @@
+---
+title: FreeRADIUS ECS Task auto scaler
+weight: 30
+last_reviewed_on: "2025-08-08"
+review_in: 12 months
+---
+# FreeRADIUS ECS Task autoscaler
+## Background
+After an outage in May 2025, it was noticed that Radius had a hard limit of EAP Open Sessions, up until this point this hadn't caused us any problems, but when this limit was reached, the health checks stared to fail which then removed
+tasks from the load balancer.
+
+Also, helpfully, radius does not log the number of open sessions, so this isn't something that can be queried or set a metric for.
+
+## Mitigations
+The number of open session has been increased massively.
+
+Added a cloudwatch alarm that will trigger if the "too many sessions" error appears in the cloudwatch logs, achieved via a log metric, with a filter for this error message.
+
+This alarm will also trigger an auto scaler, that will increase tasks to the maximum set in the terraform config for that environment, look for `radius_task_count_`(min/max).
+
+## But where is the scale down policy?
+Well, good question,  we discovered, it was tricky to detect when it was 'safe' to scale back the radius tasks automatically.
+
+Setting this on the 'OK_ACTION' is not best practice, as the alarm could 'flip/flop' causing race conditions.
+
+Setting via an inverted cloudwatch alarm meant the alarm was alway in alert state.
+
+Using a schedule was wasteful, plus terraform (in 2025) has no way to reset the desired tasks, so 2 schedules would have been required.
+
+Considered a lambda to look at the last time the error appeared in the logs and wait a specific amount of time, then trigger the scale down, but this would be complex to build, integrate and maintain.
+
+So it was decided to do this manually via a codebuild job, reasons for this were:
+
+* On-demand: Only runs when it's decided it's safe to do so.
+* Controlled: investigate first, then scale down
+* Auditable: CodeBuild logs show exactly what happened
+* Flexible: Can easily change target capacity
+* Safe: Shows before/after status
+* Simple: Much simpler than Lambda in Terraform, easier to maintain.
+


### PR DESCRIPTION
### What
Add dev docs for the radius auto scaler.

### Why
Not a straightforward piece of work, I felt some areas needed explanation, especially why I decided on a manual scale down, rather then try to automate it, and the reasons behind this.  I don't think decisions like this are not always documented and when people move on, its then unclear why x was done that way.  We have the decision log, but who remembers where that is ;) great for big decisions on why we we x app and not y, but I feel coding decisions are easier to find in our docs.

### Link to JIRA card (if applicable): 
[GW-2335](https://technologyprogramme.atlassian.net/browse/GW-2335)
