### PR TITLE
Add extra onboarding info to "Get Started Page"

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -70,9 +70,12 @@ Depending on your role, you may also need access to:
 - the GovWifi-Critical-Alerts Google group
 - the GovWifi-Feedback Google group
 
-If you need to use Github, ask the tech lead to add you to the `GovWifi` organisation and the `GovWifi` team. The main GovWifi repositories are listed on the [Learn about the GovWifi applications](/applications/#learn-about-the-govwifi-applications) page. There are further instructions on each repository.
+If you need to use Github, ask an engineering lead to add you to the `GovWifi` organisation and the `GovWifi` team. The main GovWifi repositories are listed on the [Learn about the GovWifi applications](/applications/#learn-about-the-govwifi-applications) page. There are further instructions on each repository.
 
-The Tech Lead has the Github privileges to add new team members to the `alphagov` organisation and relevant GovWifi Github teams. If the Tech Lead changes, these privileges must be transferred to the new Tech Lead. It's important to email the `gds-github-owners` Google group notifying them that a new Github organisation admin has been added and also add the new Tech Lead to the Google group.
+The Engineering Leads have the Github privileges to add new team members to the `GovWifi` organisation and relevant GovWifi Github teams. If the Engineering Leads change, these privileges must be transferred to the new Lead. 
+
+## CO Digital
+GovWifi is part of CO Digital. If you're new to the department as well as GovWifi, you can find lots of helpful information for new starters on the [CO Digital Community Hub](https://sites.google.com/cabinetoffice.gov.uk/digital-staff-pages/co-digital-induction) (you must be logged into your work gmail account in order to access this).
 
 ## Things developers need access to
 


### PR DESCRIPTION
### What
Add extra onboarding info to "Get Started Page"

### Why
Keeping things accurate.
Add link to CO Digital hub for those new to the department as well as the team. 
Correct sentence about tech lead and alphagov reference

