### PR TITLE
fix: [GW-2389] Update Middleman to fix thor security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,10 @@ gem 'wdm', '~> 0.1.1', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs', '~> 5.0.2'
+gem 'govuk_tech_docs', '~> 4.2.0'
 
 # Middleman Gems
-# Pinned to 4.5.1 due to this bug https://github.com/middleman/middleman/issues/2818
-gem 'middleman', '4.5.1'
+gem 'middleman', '~> 4.6.2'
 
 # required since ruby > 3.4
 gem 'base64'
@@ -21,3 +20,4 @@ gem 'benchmark'
 gem 'bigdecimal'
 gem 'mutex_m'
 gem 'rdoc'
+gem 'kramdown' ## replace redcarpet which breaks with middleman > 4.5.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
-    backports (3.25.1)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -42,7 +41,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     erb (5.0.1)
-    erubis (2.7.0)
+    erubi (1.13.1)
     eventmachine (1.2.7)
     execjs (2.10.0)
     fast_blank (1.0.1)
@@ -54,7 +53,7 @@ GEM
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
-    govuk_tech_docs (5.0.2)
+    govuk_tech_docs (4.2.0)
       autoprefixer-rails (~> 10.2)
       base64
       bigdecimal
@@ -62,7 +61,7 @@ GEM
       concurrent-ruby (= 1.3.4)
       csv
       haml (~> 6.0)
-      middleman (= 4.5.1)
+      middleman (~> 4.0)
       middleman-autoprefixer (~> 2.10)
       middleman-compass (~> 4.0)
       middleman-livereload
@@ -92,44 +91,44 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     memoist (0.16.2)
-    middleman (4.5.1)
-      coffee-script (~> 2.2)
-      haml (>= 4.0.5)
-      kramdown (>= 2.3.0)
-      middleman-cli (= 4.5.1)
-      middleman-core (= 4.5.1)
+    middleman (4.6.2)
+      middleman-cli (= 4.6.2)
+      middleman-core (= 4.6.2)
     middleman-autoprefixer (2.10.0)
       autoprefixer-rails (>= 9.1.4)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.5.1)
-      thor (>= 0.17.0, < 1.3.0)
+    middleman-cli (4.6.2)
+      thor (>= 0.17.0, < 2)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.5.1)
-      activesupport (>= 6.1, < 7.1)
+    middleman-core (4.6.2)
+      activesupport (>= 6.1)
       addressable (~> 2.4)
-      backports (~> 3.6)
       bundler (~> 2.0)
-      contracts (~> 0.13, < 0.17)
+      coffee-script (~> 2.2)
+      contracts
       dotenv
-      erubis
+      erubi
       execjs (~> 2.0)
       fast_blank
       fastimage (~> 2.0)
+      haml (>= 4.0.5)
       hamster (~> 3.0)
-      hashie (~> 3.4)
-      i18n (~> 1.6.0)
+      hashie (>= 3.4, < 6.0)
+      i18n (>= 1.6, < 1.15)
+      kramdown (~> 2.4)
       listen (~> 3.0)
       memoist (~> 0.14)
       padrino-helpers (~> 0.15.0)
       parallel
-      rack (>= 1.4.5, < 3)
+      rack (>= 3)
+      rackup
       sassc (~> 2.0)
       servolux
-      tilt (~> 2.0.9)
+      tilt (~> 2.2)
       toml
-      uglifier (~> 3.0)
+      uglifier (>= 3, < 5)
       webrick
     middleman-livereload (3.4.7)
       em-websocket (~> 0.5.1)
@@ -170,9 +169,11 @@ GEM
       stringio
     public_suffix (6.0.2)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (3.2.1)
     rack-livereload (0.3.17)
       rack
+    rackup (2.2.1)
+      rack (>= 3)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -206,7 +207,7 @@ GEM
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.2.2)
-    tilt (2.0.11)
+    tilt (2.6.1)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
     tzinfo (2.0.6)
@@ -226,8 +227,9 @@ DEPENDENCIES
   base64
   benchmark
   bigdecimal
-  govuk_tech_docs (~> 5.0.2)
-  middleman (= 4.5.1)
+  govuk_tech_docs (~> 4.2.0)
+  kramdown
+  middleman (~> 4.6.2)
   mutex_m
   rdoc
   tzinfo-data

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 build: stop
-	docker-compose build
+	docker compose build
 
 serve: build
-	docker-compose run --service-ports app bundle exec middleman server --watcher-force-polling
+	docker compose run --service-ports app bundle exec middleman server --watcher-force-polling
 
 stop:
-	docker-compose kill
-	docker-compose rm -f
+	docker compose kill
+	docker compose rm -f
 
 .PHONY: build deploy stop

--- a/config.rb
+++ b/config.rb
@@ -1,12 +1,14 @@
 require 'govuk_tech_docs'
+require 'kramdown'
 
+GovukTechDocs.configure(self)
+
+set :markdown_engine, :kramdown
 set :relative_links, true
 
 configure :build do
   activate :relative_assets
 end
-
-GovukTechDocs.configure(self)
 
 helpers do
   def format_date(date)


### PR DESCRIPTION
### What
Update Middleman to fix security flaw with Thor, required replacing RedCapet with Kramdown to fix 'nil for link_to' context error with renderer, had to pin the tech-docs lib to 4.2 as after this they pinned Middleman to 4.5.1 due to the aforementioned bug.

### Why
As described in What :)

### Link to JIRA card (if applicable): 
[GW-2389](https://technologyprogramme.atlassian.net/browse/GW-2389)
