### PR TITLE
fix: [GW-2784] Update github action

### DIFF
--- a/.github/workflows/build-dev-docs.yml
+++ b/.github/workflows/build-dev-docs.yml
@@ -5,23 +5,22 @@ jobs:
     build_dev_docs:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
-  
+
         - name: Setup node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6.4.0
           with:
             node-version: 'latest'
-  
+
         - name: Setup ruby
           uses: ruby/setup-ruby@v1
           with:
             bundler-cache: true
-  
+
         - name: Install ruby dependencies
           run: bundle install
-  
+
         - name: Build static site
           run: bundle exec middleman build
-  

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -10,12 +10,12 @@ jobs:
   build_dev_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 'latest'
 
@@ -31,10 +31,10 @@ jobs:
         run: bundle exec middleman build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./build
-          
+
   deploy_dev_docs:
 
     permissions:
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ruby_updater.yml
+++ b/.github/workflows/ruby_updater.yml
@@ -3,15 +3,17 @@ name: Upgrade Ruby
 on:
   workflow_dispatch:
   schedule:
-    - cron: "35 0 15 * 0" # Runs monthly (in the middle to avoid any date clashes)
+    - cron: "35 0 15 * *" # Runs monthly (in the middle to avoid any date clashes)
 
-permissions:
-  contents: write
-  pull-requests: write
+env:
+  MAIN_BRANCH: 'master'
+  MAJOR_VERSION: '3'
 
 jobs:
   check-ruby-setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       TARGET_RUBY_VERSION: ${{ steps.check-ruby.outputs.TARGET_RUBY_VERSION }}
       NEW_RUBY: ${{ steps.check-ruby.outputs.NEW_RUBY }}
@@ -20,26 +22,38 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
-
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    ## This step will check the current Ruby version against the latest available version for the specified major version. It will set outputs TARGET_RUBY_VERSION, NEW_RUBY, and RUBY_PATHS.
     - name: Check Ruby Version
       id: check-ruby
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-version-check@main
+      with:
+        major-version: ${{ env.MAJOR_VERSION }}
+
 
     - name: Setup github branch for Ruby Updates
       id: setup-branch
-      if: ${{ steps.check-ruby.outputs.NEW_RUBY }} == 'true'
+      ## Only run if the Ruby Version has changed.
+      if: ${{ steps.check-ruby.outputs.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-setup-branch@main
       env:
         TARGET_RUBY_VERSION: ${{ steps.check-ruby.outputs.TARGET_RUBY_VERSION }}
 
   upgrade-ruby:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     needs: [check-ruby-setup]
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Update Ruby Version
       env:
@@ -48,7 +62,7 @@ jobs:
          NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
          RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
       ## Only update if the Ruby Version has changed.
-      if: ${{ env.NEW_RUBY }} == 'true'
+      if: ${{ env.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater-multi-env@main
 
     - name: Commit and Raise PR
@@ -58,7 +72,7 @@ jobs:
          NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-commit-changes@main
       ## Only update if the Ruby Version has changed.
-      if: ${{ env.NEW_RUBY }} == 'true'
+      if: ${{ env.NEW_RUBY == 'true' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        main-branch: master
+        main-branch: ${{ env.MAIN_BRANCH }}


### PR DESCRIPTION
### What

Update Ruby updater workflow to narrow permissions

### Why

Akido Security audit 

Link to JIRA card (if applicable):
[GW-2784](https://technologyprogramme.atlassian.net/browse/GW-2784)
