### PR TITLE
Update dependabot.yml to ignore Ruby updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,5 @@ updates:
     time: "03:00"
   open-pull-requests-limit: 10
   ignore:
+  # Ignore updates to Ruby as this will be handled by the ruby-updater workflow.
   - dependency-name: ruby
-    versions:
-    - 3.0.0.pre.alpine


### PR DESCRIPTION
### What
Stop dependabot from trying to update Ruby

### Why
Because we have an action that now handles this, depedabot fails and just creates noise!

### Link to JIRA card (if applicable): 
n/a
