### PR TITLE
Hide 'Report problem' link in contribution banner via CSS

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,11 @@
 @import "govuk_tech_docs";
+
+// Hide the "Report problem" link in the contribution banner while keeping
+// "View source" and "GitHub Repo". The govuk_tech_docs gem renders the
+// contribution banner from its own layout (core.erb), which a project-level
+// source/layouts/core.erb override does NOT replace (the gem registers its
+// source dir after the project's, so the gem layout wins). So the link has to
+// be removed via CSS. It is the only banner link pointing at /issues/new.
+.contribution-banner li:has(a[href*="/issues/new"]) {
+  display: none;
+}


### PR DESCRIPTION
### What
Hide report problem link 

### Why
The govuk_tech_docs gem (v4.2.0) renders the contribution banner from its own core.erb layout. A project-level source/layouts/core.erb override does NOT replace it (the gem registers its source dir after the project's, so the gem layout wins) - verified with a local middleman build. The link therefore cannot be removed from the markup, so hiding it with CSS instead, targeting the only banner link pointing at /issues/new. 'View source' and 'GitHub Repo' are unaffected.

### Link to JIRA card (if applicable): 
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2801
